### PR TITLE
Drop obsolete link templates for Primo libraries.

### DIFF
--- a/data/opacLinks/isil2opac_hbzId.tsv
+++ b/data/opacLinks/isil2opac_hbzId.tsv
@@ -1,10 +1,7 @@
 DE-1010	https://w-hs.digibib.net/search/katalog/record/(DE-605){hbzid}
-DE-1042	https://grimm.umwelt-campus.de/uhtbin/cgisirsi/x/0/0/5?searchdata1={hbzid}
 DE-107	https://lbz-rlp.digibib.net/search/katalog/record/(DE-605){hbzid}
-DE-1105	https://bibopac2.rac.hs-koblenz.de/webOPACClient-Remagen/start.do?Query=0010=%22{hbzid}%22
 DE-1116	https://opac.hwg-lu.de/alipac/-/item-local?BASE=B-TIT&VID={hbzid}
 DE-1156	https://folkwang-uni.digibib.net/search/katalog/record/56:{hbzid}
-DE-121	https://aleph.zbsport.de/F/?local_base=str01&find_code=IDN&request={hbzid}&func=find-b
 DE-1383	https://hsb-rhein-waal.digibib.net/search/katalog/record/(DE-605){hbzid}
 DE-1383a	https://hsb-rhein-waal.digibib.net/search/katalog/record/(DE-605){hbzid}
 DE-1393	https://hsb-ruhr-west.digibib.net/search/katalog/record/(DE-605){hbzid}
@@ -24,14 +21,10 @@ DE-832	https://thb-koeln.digibib.net/search/katalog/record/(DE-605){hbzid}
 DE-836	https://fhb-muenster.digibib.net/search/katalog/record/(DE-605){hbzid}
 DE-929	https://lbz-rlp.digibib.net/search/katalog/record/(DE-605){hbzid}
 DE-956	https://evh-bochum.digibib.net/search/katalog/record/(DE-605){hbzid}
-DE-987	https://bibopac2.rac.hs-koblenz.de/webOPACClient-Koblenz/start.do?Query=0010=%22{hbzid}%22
 DE-A96	https://fhb-aachen.digibib.net/search/katalog/record/(DE-605){hbzid}
 DE-Bi10	https://fhb-bielefeld.digibib.net/search/katalog/record/(DE-605){hbzid}
 DE-Bm1	https://thga.digibib.net/search/katalog/record/(DE-605){hbzid}
 DE-Bm40	https://hsb-bochum.digibib.net/search/katalog/record/(DE-605){hbzid}
 DE-Due62	https://hs-duesseldorf.digibib.net/search/katalog/record/(DE-605){hbzid}
-DE-Kn28	https://katalog.dombibliothek-koeln.de/F/?local_base=edk01&find_code=IDN&request={hbzid}&func=find-b
 DE-Kn38	https://hfmt-koeln.digibib.net/search/katalog/record/58:{hbzid}
-DE-Tr2	https://katalog.dombibliothek-koeln.de/F/?local_base=ptr01&find_code=IDN&request={hbzid}&func=find-b
-DE-Tr5	https://bibserv.fh-trier.de/webOPACClient/start.do?Query=0010=%22{hbzid}%22
 DE-Zw1	https://lbz-rlp.digibib.net/search/katalog/record/(DE-605){hbzid}

--- a/data/opacLinks/isil2opac_issn.tsv
+++ b/data/opacLinks/isil2opac_issn.tsv
@@ -1,5 +1,1 @@
-DE-1042	https://grimm.umwelt-campus.de/uhtbin/cgisirsi/x/0/0/5?searchdata1={issn}
-DE-121	https://aleph.zbsport.de/F/?func=find-word&scan_code=WRD&scan_word={issn}&local_base=str01
-DE-Kn28	https://katalog.dombibliothek-koeln.de/F/?local_base=edk01&find_code=ISN&request={issn}&func=find-b
-DE-Tr2	https://katalog.dombibliothek-koeln.de/F/?local_base=ptr01&find_code=IDN&request={issn}&func=find-b
 DE-60	https://stlb-dortmund.digibib.net/search/katalog/list?defaults=on&q-is={issn}


### PR DESCRIPTION
Everything covered by Alma MMS ID.