### PR TITLE
Add MARC relator codes.

### DIFF
--- a/data/marc-relators.tsv
+++ b/data/marc-relators.tsv
@@ -1,0 +1,311 @@
+uri	code	term
+http://id.loc.gov/vocabulary/relators/abr	abr	abridger
+http://id.loc.gov/vocabulary/relators/acp	acp	art copyist
+http://id.loc.gov/vocabulary/relators/act	act	actor
+http://id.loc.gov/vocabulary/relators/adi	adi	art director
+http://id.loc.gov/vocabulary/relators/adp	adp	adapter
+http://id.loc.gov/vocabulary/relators/afd	afd	assistant film director
+http://id.loc.gov/vocabulary/relators/aft	aft	author of afterword, colophon, etc.
+http://id.loc.gov/vocabulary/relators/anc	anc	announcer
+http://id.loc.gov/vocabulary/relators/anl	anl	analyst
+http://id.loc.gov/vocabulary/relators/anm	anm	animator
+http://id.loc.gov/vocabulary/relators/ann	ann	annotator
+http://id.loc.gov/vocabulary/relators/ant	ant	bibliographic antecedent
+http://id.loc.gov/vocabulary/relators/apb	apb	approbator
+http://id.loc.gov/vocabulary/relators/ape	ape	appellee
+http://id.loc.gov/vocabulary/relators/apl	apl	appellant
+http://id.loc.gov/vocabulary/relators/app	app	applicant
+http://id.loc.gov/vocabulary/relators/aqt	aqt	author in quotations or text abstracts
+http://id.loc.gov/vocabulary/relators/arc	arc	architect
+http://id.loc.gov/vocabulary/relators/ard	ard	artistic director
+http://id.loc.gov/vocabulary/relators/arr	arr	arranger
+http://id.loc.gov/vocabulary/relators/art	art	artist
+http://id.loc.gov/vocabulary/relators/asg	asg	assignee
+http://id.loc.gov/vocabulary/relators/asn	asn	associated name
+http://id.loc.gov/vocabulary/relators/ato	ato	autographer
+http://id.loc.gov/vocabulary/relators/att	att	attributed name
+http://id.loc.gov/vocabulary/relators/auc	auc	auctioneer
+http://id.loc.gov/vocabulary/relators/aud	aud	author of dialog
+http://id.loc.gov/vocabulary/relators/aue	aue	audio engineer
+http://id.loc.gov/vocabulary/relators/aui	aui	author of introduction, etc.
+http://id.loc.gov/vocabulary/relators/aup	aup	audio producer
+http://id.loc.gov/vocabulary/relators/aus	aus	screenwriter
+http://id.loc.gov/vocabulary/relators/aut	aut	author
+http://id.loc.gov/vocabulary/relators/bdd	bdd	binding designer
+http://id.loc.gov/vocabulary/relators/bjd	bjd	bookjacket designer
+http://id.loc.gov/vocabulary/relators/bka	bka	book artist
+http://id.loc.gov/vocabulary/relators/bkd	bkd	book designer
+http://id.loc.gov/vocabulary/relators/bkp	bkp	book producer
+http://id.loc.gov/vocabulary/relators/blw	blw	blurb writer
+http://id.loc.gov/vocabulary/relators/bnd	bnd	binder
+http://id.loc.gov/vocabulary/relators/bpd	bpd	bookplate designer
+http://id.loc.gov/vocabulary/relators/brd	brd	broadcaster
+http://id.loc.gov/vocabulary/relators/brl	brl	braille embosser
+http://id.loc.gov/vocabulary/relators/bsl	bsl	bookseller
+http://id.loc.gov/vocabulary/relators/cad	cad	casting director
+http://id.loc.gov/vocabulary/relators/cas	cas	caster
+http://id.loc.gov/vocabulary/relators/ccp	ccp	conceptor
+http://id.loc.gov/vocabulary/relators/chr	chr	choreographer
+http://id.loc.gov/vocabulary/relators/clb	clb	collaborator
+http://id.loc.gov/vocabulary/relators/cli	cli	client
+http://id.loc.gov/vocabulary/relators/cll	cll	calligrapher
+http://id.loc.gov/vocabulary/relators/clr	clr	colorist
+http://id.loc.gov/vocabulary/relators/clt	clt	collotyper
+http://id.loc.gov/vocabulary/relators/cmm	cmm	commentator
+http://id.loc.gov/vocabulary/relators/cmp	cmp	composer
+http://id.loc.gov/vocabulary/relators/cmt	cmt	compositor
+http://id.loc.gov/vocabulary/relators/cnd	cnd	conductor
+http://id.loc.gov/vocabulary/relators/cng	cng	cinematographer
+http://id.loc.gov/vocabulary/relators/cns	cns	censor
+http://id.loc.gov/vocabulary/relators/coe	coe	contestant-appellee
+http://id.loc.gov/vocabulary/relators/col	col	collector
+http://id.loc.gov/vocabulary/relators/com	com	compiler
+http://id.loc.gov/vocabulary/relators/con	con	conservator
+http://id.loc.gov/vocabulary/relators/cop	cop	camera operator
+http://id.loc.gov/vocabulary/relators/cor	cor	collection registrar
+http://id.loc.gov/vocabulary/relators/cos	cos	contestant
+http://id.loc.gov/vocabulary/relators/cot	cot	contestant-appellant
+http://id.loc.gov/vocabulary/relators/cou	cou	court governed
+http://id.loc.gov/vocabulary/relators/cov	cov	cover designer
+http://id.loc.gov/vocabulary/relators/cpc	cpc	copyright claimant
+http://id.loc.gov/vocabulary/relators/cpe	cpe	complainant-appellee
+http://id.loc.gov/vocabulary/relators/cph	cph	copyright holder
+http://id.loc.gov/vocabulary/relators/cpl	cpl	complainant
+http://id.loc.gov/vocabulary/relators/cpt	cpt	complainant-appellant
+http://id.loc.gov/vocabulary/relators/cre	cre	creator
+http://id.loc.gov/vocabulary/relators/crp	crp	correspondent
+http://id.loc.gov/vocabulary/relators/crr	crr	corrector
+http://id.loc.gov/vocabulary/relators/crt	crt	court reporter
+http://id.loc.gov/vocabulary/relators/csl	csl	consultant
+http://id.loc.gov/vocabulary/relators/csp	csp	consultant to a project
+http://id.loc.gov/vocabulary/relators/cst	cst	costume designer
+http://id.loc.gov/vocabulary/relators/ctb	ctb	contributor
+http://id.loc.gov/vocabulary/relators/cte	cte	contestee-appellee
+http://id.loc.gov/vocabulary/relators/ctg	ctg	cartographer
+http://id.loc.gov/vocabulary/relators/ctr	ctr	contractor
+http://id.loc.gov/vocabulary/relators/cts	cts	contestee
+http://id.loc.gov/vocabulary/relators/ctt	ctt	contestee-appellant
+http://id.loc.gov/vocabulary/relators/cur	cur	curator
+http://id.loc.gov/vocabulary/relators/cwt	cwt	commentator for written text
+http://id.loc.gov/vocabulary/relators/dbd	dbd	dubbing director
+http://id.loc.gov/vocabulary/relators/dbp	dbp	distribution place
+http://id.loc.gov/vocabulary/relators/dfd	dfd	defendant
+http://id.loc.gov/vocabulary/relators/dfe	dfe	defendant-appellee
+http://id.loc.gov/vocabulary/relators/dft	dft	defendant-appellant
+http://id.loc.gov/vocabulary/relators/dgc	dgc	degree committee member
+http://id.loc.gov/vocabulary/relators/dgg	dgg	degree granting institution
+http://id.loc.gov/vocabulary/relators/dgs	dgs	degree supervisor
+http://id.loc.gov/vocabulary/relators/dis	dis	dissertant
+http://id.loc.gov/vocabulary/relators/djo	djo	dj
+http://id.loc.gov/vocabulary/relators/dln	dln	delineator
+http://id.loc.gov/vocabulary/relators/dnc	dnc	dancer
+http://id.loc.gov/vocabulary/relators/dnr	dnr	donor
+http://id.loc.gov/vocabulary/relators/dpc	dpc	depicted
+http://id.loc.gov/vocabulary/relators/dpt	dpt	depositor
+http://id.loc.gov/vocabulary/relators/drm	drm	draftsman
+http://id.loc.gov/vocabulary/relators/drt	drt	director
+http://id.loc.gov/vocabulary/relators/dsr	dsr	designer
+http://id.loc.gov/vocabulary/relators/dst	dst	distributor
+http://id.loc.gov/vocabulary/relators/dtc	dtc	data contributor
+http://id.loc.gov/vocabulary/relators/dte	dte	dedicatee
+http://id.loc.gov/vocabulary/relators/dtm	dtm	data manager
+http://id.loc.gov/vocabulary/relators/dto	dto	dedicator
+http://id.loc.gov/vocabulary/relators/dub	dub	dubious author
+http://id.loc.gov/vocabulary/relators/edc	edc	editor of compilation
+http://id.loc.gov/vocabulary/relators/edd	edd	editorial director
+http://id.loc.gov/vocabulary/relators/edm	edm	editor of moving image work
+http://id.loc.gov/vocabulary/relators/edt	edt	editor
+http://id.loc.gov/vocabulary/relators/egr	egr	engraver
+http://id.loc.gov/vocabulary/relators/elg	elg	electrician
+http://id.loc.gov/vocabulary/relators/elt	elt	electrotyper
+http://id.loc.gov/vocabulary/relators/eng	eng	engineer
+http://id.loc.gov/vocabulary/relators/enj	enj	enacting jurisdiction
+http://id.loc.gov/vocabulary/relators/etr	etr	etcher
+http://id.loc.gov/vocabulary/relators/evp	evp	event place
+http://id.loc.gov/vocabulary/relators/exp	exp	expert
+http://id.loc.gov/vocabulary/relators/fac	fac	facsimilist
+http://id.loc.gov/vocabulary/relators/fds	fds	film distributor
+http://id.loc.gov/vocabulary/relators/fld	fld	field director
+http://id.loc.gov/vocabulary/relators/flm	flm	film editor
+http://id.loc.gov/vocabulary/relators/fmd	fmd	film director
+http://id.loc.gov/vocabulary/relators/fmk	fmk	filmmaker
+http://id.loc.gov/vocabulary/relators/fmo	fmo	former owner
+http://id.loc.gov/vocabulary/relators/fmp	fmp	film producer
+http://id.loc.gov/vocabulary/relators/fnd	fnd	funder
+http://id.loc.gov/vocabulary/relators/fon	fon	founder
+http://id.loc.gov/vocabulary/relators/fpy	fpy	first party
+http://id.loc.gov/vocabulary/relators/frg	frg	forger
+http://id.loc.gov/vocabulary/relators/gdv	gdv	game developer
+http://id.loc.gov/vocabulary/relators/gis	gis	geographic information specialist
+http://id.loc.gov/vocabulary/relators/grt	grt	graphic technician
+http://id.loc.gov/vocabulary/relators/gst	gst	guest
+http://id.loc.gov/vocabulary/relators/his	his	host institution
+http://id.loc.gov/vocabulary/relators/hnr	hnr	honoree
+http://id.loc.gov/vocabulary/relators/hst	hst	host
+http://id.loc.gov/vocabulary/relators/ill	ill	illustrator
+http://id.loc.gov/vocabulary/relators/ilu	ilu	illuminator
+http://id.loc.gov/vocabulary/relators/ink	ink	inker
+http://id.loc.gov/vocabulary/relators/ins	ins	inscriber
+http://id.loc.gov/vocabulary/relators/inv	inv	inventor
+http://id.loc.gov/vocabulary/relators/isb	isb	issuing body
+http://id.loc.gov/vocabulary/relators/itr	itr	instrumentalist
+http://id.loc.gov/vocabulary/relators/ive	ive	interviewee
+http://id.loc.gov/vocabulary/relators/ivr	ivr	interviewer
+http://id.loc.gov/vocabulary/relators/jud	jud	judge
+http://id.loc.gov/vocabulary/relators/jug	jug	jurisdiction governed
+http://id.loc.gov/vocabulary/relators/lbr	lbr	laboratory
+http://id.loc.gov/vocabulary/relators/lbt	lbt	librettist
+http://id.loc.gov/vocabulary/relators/ldr	ldr	laboratory director
+http://id.loc.gov/vocabulary/relators/led	led	lead
+http://id.loc.gov/vocabulary/relators/lee	lee	libelee-appellee
+http://id.loc.gov/vocabulary/relators/lel	lel	libelee
+http://id.loc.gov/vocabulary/relators/len	len	lender
+http://id.loc.gov/vocabulary/relators/let	let	libelee-appellant
+http://id.loc.gov/vocabulary/relators/lgd	lgd	lighting designer
+http://id.loc.gov/vocabulary/relators/lie	lie	libelant-appellee
+http://id.loc.gov/vocabulary/relators/lil	lil	libelant
+http://id.loc.gov/vocabulary/relators/lit	lit	libelant-appellant
+http://id.loc.gov/vocabulary/relators/lsa	lsa	landscape architect
+http://id.loc.gov/vocabulary/relators/lse	lse	licensee
+http://id.loc.gov/vocabulary/relators/lso	lso	licensor
+http://id.loc.gov/vocabulary/relators/ltg	ltg	lithographer
+http://id.loc.gov/vocabulary/relators/ltr	ltr	letterer
+http://id.loc.gov/vocabulary/relators/lyr	lyr	lyricist
+http://id.loc.gov/vocabulary/relators/mcp	mcp	music copyist
+http://id.loc.gov/vocabulary/relators/mdc	mdc	metadata contact
+http://id.loc.gov/vocabulary/relators/med	med	medium
+http://id.loc.gov/vocabulary/relators/mfp	mfp	manufacture place
+http://id.loc.gov/vocabulary/relators/mfr	mfr	manufacturer
+http://id.loc.gov/vocabulary/relators/mka	mka	makeup artist
+http://id.loc.gov/vocabulary/relators/mod	mod	moderator
+http://id.loc.gov/vocabulary/relators/mon	mon	monitor
+http://id.loc.gov/vocabulary/relators/mrb	mrb	marbler
+http://id.loc.gov/vocabulary/relators/mrk	mrk	markup editor
+http://id.loc.gov/vocabulary/relators/msd	msd	musical director
+http://id.loc.gov/vocabulary/relators/mte	mte	metal engraver
+http://id.loc.gov/vocabulary/relators/mtk	mtk	minute taker
+http://id.loc.gov/vocabulary/relators/mup	mup	music programmer
+http://id.loc.gov/vocabulary/relators/mus	mus	musician
+http://id.loc.gov/vocabulary/relators/mxe	mxe	mixing engineer
+http://id.loc.gov/vocabulary/relators/nan	nan	news anchor
+http://id.loc.gov/vocabulary/relators/nrt	nrt	narrator
+http://id.loc.gov/vocabulary/relators/onp	onp	onscreen participant
+http://id.loc.gov/vocabulary/relators/opn	opn	opponent
+http://id.loc.gov/vocabulary/relators/org	org	originator
+http://id.loc.gov/vocabulary/relators/orm	orm	organizer
+http://id.loc.gov/vocabulary/relators/osp	osp	onscreen presenter
+http://id.loc.gov/vocabulary/relators/oth	oth	other
+http://id.loc.gov/vocabulary/relators/own	own	owner
+http://id.loc.gov/vocabulary/relators/pad	pad	place of address
+http://id.loc.gov/vocabulary/relators/pan	pan	panelist
+http://id.loc.gov/vocabulary/relators/pat	pat	patron
+http://id.loc.gov/vocabulary/relators/pbd	pbd	publisher director
+http://id.loc.gov/vocabulary/relators/pbl	pbl	publisher
+http://id.loc.gov/vocabulary/relators/pdr	pdr	project director
+http://id.loc.gov/vocabulary/relators/pfr	pfr	proofreader
+http://id.loc.gov/vocabulary/relators/pht	pht	photographer
+http://id.loc.gov/vocabulary/relators/plt	plt	platemaker
+http://id.loc.gov/vocabulary/relators/pma	pma	permitting agency
+http://id.loc.gov/vocabulary/relators/pmn	pmn	production manager
+http://id.loc.gov/vocabulary/relators/pnc	pnc	penciller
+http://id.loc.gov/vocabulary/relators/pop	pop	printer of plates
+http://id.loc.gov/vocabulary/relators/ppm	ppm	papermaker
+http://id.loc.gov/vocabulary/relators/ppt	ppt	puppeteer
+http://id.loc.gov/vocabulary/relators/pra	pra	praeses
+http://id.loc.gov/vocabulary/relators/prc	prc	process contact
+http://id.loc.gov/vocabulary/relators/prd	prd	production personnel
+http://id.loc.gov/vocabulary/relators/pre	pre	presenter
+http://id.loc.gov/vocabulary/relators/prf	prf	performer
+http://id.loc.gov/vocabulary/relators/prg	prg	programmer
+http://id.loc.gov/vocabulary/relators/prm	prm	printmaker
+http://id.loc.gov/vocabulary/relators/prn	prn	production company
+http://id.loc.gov/vocabulary/relators/pro	pro	producer
+http://id.loc.gov/vocabulary/relators/prp	prp	production place
+http://id.loc.gov/vocabulary/relators/prs	prs	production designer
+http://id.loc.gov/vocabulary/relators/prt	prt	printer
+http://id.loc.gov/vocabulary/relators/prv	prv	provider
+http://id.loc.gov/vocabulary/relators/pta	pta	patent applicant
+http://id.loc.gov/vocabulary/relators/pte	pte	plaintiff-appellee
+http://id.loc.gov/vocabulary/relators/ptf	ptf	plaintiff
+http://id.loc.gov/vocabulary/relators/pth	pth	patent holder
+http://id.loc.gov/vocabulary/relators/ptt	ptt	plaintiff-appellant
+http://id.loc.gov/vocabulary/relators/pup	pup	publication place
+http://id.loc.gov/vocabulary/relators/rap	rap	rapporteur
+http://id.loc.gov/vocabulary/relators/rbr	rbr	rubricator
+http://id.loc.gov/vocabulary/relators/rcd	rcd	recordist
+http://id.loc.gov/vocabulary/relators/rce	rce	recording engineer
+http://id.loc.gov/vocabulary/relators/rcp	rcp	addressee
+http://id.loc.gov/vocabulary/relators/rdd	rdd	radio director
+http://id.loc.gov/vocabulary/relators/red	red	redaktor
+http://id.loc.gov/vocabulary/relators/ren	ren	renderer
+http://id.loc.gov/vocabulary/relators/res	res	researcher
+http://id.loc.gov/vocabulary/relators/rev	rev	reviewer
+http://id.loc.gov/vocabulary/relators/rpc	rpc	radio producer
+http://id.loc.gov/vocabulary/relators/rps	rps	repository
+http://id.loc.gov/vocabulary/relators/rpt	rpt	reporter
+http://id.loc.gov/vocabulary/relators/rpy	rpy	responsible party
+http://id.loc.gov/vocabulary/relators/rse	rse	respondent-appellee
+http://id.loc.gov/vocabulary/relators/rsg	rsg	restager
+http://id.loc.gov/vocabulary/relators/rsp	rsp	respondent
+http://id.loc.gov/vocabulary/relators/rsr	rsr	restorationist
+http://id.loc.gov/vocabulary/relators/rst	rst	respondent-appellant
+http://id.loc.gov/vocabulary/relators/rth	rth	research team head
+http://id.loc.gov/vocabulary/relators/rtm	rtm	research team member
+http://id.loc.gov/vocabulary/relators/rxa	rxa	remix artist
+http://id.loc.gov/vocabulary/relators/sad	sad	scientific advisor
+http://id.loc.gov/vocabulary/relators/sce	sce	scenarist
+http://id.loc.gov/vocabulary/relators/scl	scl	sculptor
+http://id.loc.gov/vocabulary/relators/scr	scr	scribe
+http://id.loc.gov/vocabulary/relators/sde	sde	sound engineer
+http://id.loc.gov/vocabulary/relators/sds	sds	sound designer
+http://id.loc.gov/vocabulary/relators/sec	sec	secretary
+http://id.loc.gov/vocabulary/relators/sfx	sfx	special effects provider
+http://id.loc.gov/vocabulary/relators/sgd	sgd	stage director
+http://id.loc.gov/vocabulary/relators/sgn	sgn	signer
+http://id.loc.gov/vocabulary/relators/sht	sht	supporting host
+http://id.loc.gov/vocabulary/relators/sll	sll	seller
+http://id.loc.gov/vocabulary/relators/sng	sng	singer
+http://id.loc.gov/vocabulary/relators/spk	spk	speaker
+http://id.loc.gov/vocabulary/relators/spn	spn	sponsor
+http://id.loc.gov/vocabulary/relators/spy	spy	second party
+http://id.loc.gov/vocabulary/relators/srv	srv	surveyor
+http://id.loc.gov/vocabulary/relators/std	std	set designer
+http://id.loc.gov/vocabulary/relators/stg	stg	setting
+http://id.loc.gov/vocabulary/relators/stl	stl	storyteller
+http://id.loc.gov/vocabulary/relators/stm	stm	stage manager
+http://id.loc.gov/vocabulary/relators/stn	stn	standards body
+http://id.loc.gov/vocabulary/relators/str	str	stereotyper
+http://id.loc.gov/vocabulary/relators/swd	swd	software developer
+http://id.loc.gov/vocabulary/relators/tad	tad	technical advisor
+http://id.loc.gov/vocabulary/relators/tau	tau	television writer
+http://id.loc.gov/vocabulary/relators/tcd	tcd	technical director
+http://id.loc.gov/vocabulary/relators/tch	tch	teacher
+http://id.loc.gov/vocabulary/relators/ths	ths	thesis advisor
+http://id.loc.gov/vocabulary/relators/tld	tld	television director
+http://id.loc.gov/vocabulary/relators/tlg	tlg	television guest
+http://id.loc.gov/vocabulary/relators/tlh	tlh	television host
+http://id.loc.gov/vocabulary/relators/tlp	tlp	television producer
+http://id.loc.gov/vocabulary/relators/trc	trc	transcriber
+http://id.loc.gov/vocabulary/relators/trl	trl	translator
+http://id.loc.gov/vocabulary/relators/tyd	tyd	type designer
+http://id.loc.gov/vocabulary/relators/tyg	tyg	typographer
+http://id.loc.gov/vocabulary/relators/uvp	uvp	university place
+http://id.loc.gov/vocabulary/relators/vac	vac	voice actor
+http://id.loc.gov/vocabulary/relators/vdg	vdg	videographer
+http://id.loc.gov/vocabulary/relators/vfx	vfx	visual effects provider
+http://id.loc.gov/vocabulary/relators/voc	voc	vocalist
+http://id.loc.gov/vocabulary/relators/wac	wac	writer of added commentary
+http://id.loc.gov/vocabulary/relators/wal	wal	writer of added lyrics
+http://id.loc.gov/vocabulary/relators/wam	wam	writer of accompanying material
+http://id.loc.gov/vocabulary/relators/wat	wat	writer of added text
+http://id.loc.gov/vocabulary/relators/waw	waw	writer of afterword
+http://id.loc.gov/vocabulary/relators/wdc	wdc	woodcutter
+http://id.loc.gov/vocabulary/relators/wde	wde	wood engraver
+http://id.loc.gov/vocabulary/relators/wfs	wfs	writer of film story
+http://id.loc.gov/vocabulary/relators/wft	wft	writer of intertitles
+http://id.loc.gov/vocabulary/relators/wfw	wfw	writer of foreword
+http://id.loc.gov/vocabulary/relators/win	win	writer of introduction
+http://id.loc.gov/vocabulary/relators/wit	wit	witness
+http://id.loc.gov/vocabulary/relators/wpr	wpr	writer of preface
+http://id.loc.gov/vocabulary/relators/wst	wst	writer of supplementary textual content
+http://id.loc.gov/vocabulary/relators/wts	wts	writer of television story

--- a/data/marc-relators.tsv
+++ b/data/marc-relators.tsv
@@ -1,136 +1,136 @@
-uri	code	term
-http://id.loc.gov/vocabulary/relators/abr	abr	abridger
+uri	code	term	label@en	label@de
+http://id.loc.gov/vocabulary/relators/abr	abr	abridger	Abridger	Kürzende/r
 http://id.loc.gov/vocabulary/relators/acp	acp	art copyist
-http://id.loc.gov/vocabulary/relators/act	act	actor
-http://id.loc.gov/vocabulary/relators/adi	adi	art director
+http://id.loc.gov/vocabulary/relators/act	act	actor	Actor	Schauspieler/in
+http://id.loc.gov/vocabulary/relators/adi	adi	art director	Art director	Art Director
 http://id.loc.gov/vocabulary/relators/adp	adp	adapter
 http://id.loc.gov/vocabulary/relators/afd	afd	assistant film director
-http://id.loc.gov/vocabulary/relators/aft	aft	author of afterword, colophon, etc.
+http://id.loc.gov/vocabulary/relators/aft	aft	author of afterword, colophon, etc.	Writer of afterword	Verfasser/in eines Nachworts
 http://id.loc.gov/vocabulary/relators/anc	anc	announcer
 http://id.loc.gov/vocabulary/relators/anl	anl	analyst
-http://id.loc.gov/vocabulary/relators/anm	anm	animator
-http://id.loc.gov/vocabulary/relators/ann	ann	annotator
-http://id.loc.gov/vocabulary/relators/ant	ant	bibliographic antecedent
+http://id.loc.gov/vocabulary/relators/anm	anm	animator	Animator	Animation
+http://id.loc.gov/vocabulary/relators/ann	ann	annotator	Annotator	Annotationen
+http://id.loc.gov/vocabulary/relators/ant	ant	bibliographic antecedent	Bibliographic antecedent	Basiert auf einem Werk von
 http://id.loc.gov/vocabulary/relators/apb	apb	approbator
-http://id.loc.gov/vocabulary/relators/ape	ape	appellee
-http://id.loc.gov/vocabulary/relators/apl	apl	appellant
+http://id.loc.gov/vocabulary/relators/ape	ape	appellee	Appellee	Berufungsbeklagte/r / Revisionsbeklagte/r
+http://id.loc.gov/vocabulary/relators/apl	apl	appellant	Appellant	Berufungskläger/in / Revisionskläger/in
 http://id.loc.gov/vocabulary/relators/app	app	applicant
 http://id.loc.gov/vocabulary/relators/aqt	aqt	author in quotations or text abstracts
-http://id.loc.gov/vocabulary/relators/arc	arc	architect
+http://id.loc.gov/vocabulary/relators/arc	arc	architect	Architect	Architekt/in
 http://id.loc.gov/vocabulary/relators/ard	ard	artistic director
-http://id.loc.gov/vocabulary/relators/arr	arr	arranger
-http://id.loc.gov/vocabulary/relators/art	art	artist
+http://id.loc.gov/vocabulary/relators/arr	arr	arranger	Arranger of music	Arrangement
+http://id.loc.gov/vocabulary/relators/art	art	artist	Artist	Künstler/in
 http://id.loc.gov/vocabulary/relators/asg	asg	assignee
 http://id.loc.gov/vocabulary/relators/asn	asn	associated name
-http://id.loc.gov/vocabulary/relators/ato	ato	autographer
+http://id.loc.gov/vocabulary/relators/ato	ato	autographer	Autographer	Unterzeichner/in
 http://id.loc.gov/vocabulary/relators/att	att	attributed name
 http://id.loc.gov/vocabulary/relators/auc	auc	auctioneer
 http://id.loc.gov/vocabulary/relators/aud	aud	author of dialog
 http://id.loc.gov/vocabulary/relators/aue	aue	audio engineer
-http://id.loc.gov/vocabulary/relators/aui	aui	author of introduction, etc.
+http://id.loc.gov/vocabulary/relators/aui	aui	author of introduction, etc.	Writer of foreword	Vorwort
 http://id.loc.gov/vocabulary/relators/aup	aup	audio producer
-http://id.loc.gov/vocabulary/relators/aus	aus	screenwriter
-http://id.loc.gov/vocabulary/relators/aut	aut	author
+http://id.loc.gov/vocabulary/relators/aus	aus	screenwriter	Screenwriter	Drehbuch
+http://id.loc.gov/vocabulary/relators/aut	aut	author	Author	Autor/in
 http://id.loc.gov/vocabulary/relators/bdd	bdd	binding designer
 http://id.loc.gov/vocabulary/relators/bjd	bjd	bookjacket designer
 http://id.loc.gov/vocabulary/relators/bka	bka	book artist
-http://id.loc.gov/vocabulary/relators/bkd	bkd	book designer
+http://id.loc.gov/vocabulary/relators/bkd	bkd	book designer	Book designer	Buchgestaltung
 http://id.loc.gov/vocabulary/relators/bkp	bkp	book producer
 http://id.loc.gov/vocabulary/relators/blw	blw	blurb writer
-http://id.loc.gov/vocabulary/relators/bnd	bnd	binder
+http://id.loc.gov/vocabulary/relators/bnd	bnd	binder	Binder	Buchbinder/in
 http://id.loc.gov/vocabulary/relators/bpd	bpd	bookplate designer
-http://id.loc.gov/vocabulary/relators/brd	brd	broadcaster
-http://id.loc.gov/vocabulary/relators/brl	brl	braille embosser
+http://id.loc.gov/vocabulary/relators/brd	brd	broadcaster	Broadcaster	Sender
+http://id.loc.gov/vocabulary/relators/brl	brl	braille embosser	Braille embosser	Brailleprägung
 http://id.loc.gov/vocabulary/relators/bsl	bsl	bookseller
 http://id.loc.gov/vocabulary/relators/cad	cad	casting director
-http://id.loc.gov/vocabulary/relators/cas	cas	caster
+http://id.loc.gov/vocabulary/relators/cas	cas	caster	Caster	Formguss
 http://id.loc.gov/vocabulary/relators/ccp	ccp	conceptor
-http://id.loc.gov/vocabulary/relators/chr	chr	choreographer
-http://id.loc.gov/vocabulary/relators/clb	clb	collaborator
+http://id.loc.gov/vocabulary/relators/chr	chr	choreographer	Choreographer	Choreographie
+http://id.loc.gov/vocabulary/relators/clb	clb	collaborator	Collaborator	Mitarbeit
 http://id.loc.gov/vocabulary/relators/cli	cli	client
-http://id.loc.gov/vocabulary/relators/cll	cll	calligrapher
-http://id.loc.gov/vocabulary/relators/clr	clr	colorist
-http://id.loc.gov/vocabulary/relators/clt	clt	collotyper
-http://id.loc.gov/vocabulary/relators/cmm	cmm	commentator
-http://id.loc.gov/vocabulary/relators/cmp	cmp	composer
+http://id.loc.gov/vocabulary/relators/cll	cll	calligrapher	Calligrapher	Kalligrafie
+http://id.loc.gov/vocabulary/relators/clr	clr	colorist	Colourist	Kolorierung
+http://id.loc.gov/vocabulary/relators/clt	clt	collotyper	Collotyper	Lichtdruck
+http://id.loc.gov/vocabulary/relators/cmm	cmm	commentator	Commentator	Kommentar
+http://id.loc.gov/vocabulary/relators/cmp	cmp	composer	Composer	Komposition
 http://id.loc.gov/vocabulary/relators/cmt	cmt	compositor
-http://id.loc.gov/vocabulary/relators/cnd	cnd	conductor
-http://id.loc.gov/vocabulary/relators/cng	cng	cinematographer
-http://id.loc.gov/vocabulary/relators/cns	cns	censor
+http://id.loc.gov/vocabulary/relators/cnd	cnd	conductor	Conductor	Dirigent/in / Leitung
+http://id.loc.gov/vocabulary/relators/cng	cng	cinematographer	Cinematographer	Kamera
+http://id.loc.gov/vocabulary/relators/cns	cns	censor	Censor	Zensor/in
 http://id.loc.gov/vocabulary/relators/coe	coe	contestant-appellee
-http://id.loc.gov/vocabulary/relators/col	col	collector
-http://id.loc.gov/vocabulary/relators/com	com	compiler
+http://id.loc.gov/vocabulary/relators/col	col	collector	Collector	Sammler/in
+http://id.loc.gov/vocabulary/relators/com	com	compiler	Compiler	Zusammengestellt von
 http://id.loc.gov/vocabulary/relators/con	con	conservator
 http://id.loc.gov/vocabulary/relators/cop	cop	camera operator
-http://id.loc.gov/vocabulary/relators/cor	cor	collection registrar
+http://id.loc.gov/vocabulary/relators/cor	cor	collection registrar	Collection registrar	Registrar/in
 http://id.loc.gov/vocabulary/relators/cos	cos	contestant
 http://id.loc.gov/vocabulary/relators/cot	cot	contestant-appellant
-http://id.loc.gov/vocabulary/relators/cou	cou	court governed
+http://id.loc.gov/vocabulary/relators/cou	cou	court governed	Court governed	Durch Verfahrensvorschriften geregeltes Gericht
 http://id.loc.gov/vocabulary/relators/cov	cov	cover designer
 http://id.loc.gov/vocabulary/relators/cpc	cpc	copyright claimant
 http://id.loc.gov/vocabulary/relators/cpe	cpe	complainant-appellee
 http://id.loc.gov/vocabulary/relators/cph	cph	copyright holder
 http://id.loc.gov/vocabulary/relators/cpl	cpl	complainant
 http://id.loc.gov/vocabulary/relators/cpt	cpt	complainant-appellant
-http://id.loc.gov/vocabulary/relators/cre	cre	creator
+http://id.loc.gov/vocabulary/relators/cre	cre	creator	Creator	Schöpfer/in
 http://id.loc.gov/vocabulary/relators/crp	crp	correspondent
 http://id.loc.gov/vocabulary/relators/crr	crr	corrector
-http://id.loc.gov/vocabulary/relators/crt	crt	court reporter
-http://id.loc.gov/vocabulary/relators/csl	csl	consultant
+http://id.loc.gov/vocabulary/relators/crt	crt	court reporter	Court reporter	Gerichtsstenograf/in
+http://id.loc.gov/vocabulary/relators/csl	csl	consultant	Consultant	Beratung
 http://id.loc.gov/vocabulary/relators/csp	csp	consultant to a project
-http://id.loc.gov/vocabulary/relators/cst	cst	costume designer
-http://id.loc.gov/vocabulary/relators/ctb	ctb	contributor
+http://id.loc.gov/vocabulary/relators/cst	cst	costume designer	Costume designer	Kostümdesign
+http://id.loc.gov/vocabulary/relators/ctb	ctb	contributor	Contributor	Beitragende/r
 http://id.loc.gov/vocabulary/relators/cte	cte	contestee-appellee
-http://id.loc.gov/vocabulary/relators/ctg	ctg	cartographer
-http://id.loc.gov/vocabulary/relators/ctr	ctr	contractor
+http://id.loc.gov/vocabulary/relators/ctg	ctg	cartographer	Cartographer	Kartografie
+http://id.loc.gov/vocabulary/relators/ctr	ctr	contractor	Participant in a treaty	Vertragspartner/in
 http://id.loc.gov/vocabulary/relators/cts	cts	contestee
 http://id.loc.gov/vocabulary/relators/ctt	ctt	contestee-appellant
-http://id.loc.gov/vocabulary/relators/cur	cur	curator
+http://id.loc.gov/vocabulary/relators/cur	cur	curator	Curator	Kurator/in
 http://id.loc.gov/vocabulary/relators/cwt	cwt	commentator for written text
 http://id.loc.gov/vocabulary/relators/dbd	dbd	dubbing director
 http://id.loc.gov/vocabulary/relators/dbp	dbp	distribution place
-http://id.loc.gov/vocabulary/relators/dfd	dfd	defendant
+http://id.loc.gov/vocabulary/relators/dfd	dfd	defendant	Defendant	Angeklagte/r
 http://id.loc.gov/vocabulary/relators/dfe	dfe	defendant-appellee
 http://id.loc.gov/vocabulary/relators/dft	dft	defendant-appellant
 http://id.loc.gov/vocabulary/relators/dgc	dgc	degree committee member
-http://id.loc.gov/vocabulary/relators/dgg	dgg	degree granting institution
-http://id.loc.gov/vocabulary/relators/dgs	dgs	degree supervisor
+http://id.loc.gov/vocabulary/relators/dgg	dgg	degree granting institution	Degree granting institution	Grad-verleihende Institution
+http://id.loc.gov/vocabulary/relators/dgs	dgs	degree supervisor	Degree supervisor	Akademische Betreuung
 http://id.loc.gov/vocabulary/relators/dis	dis	dissertant
 http://id.loc.gov/vocabulary/relators/djo	djo	dj
 http://id.loc.gov/vocabulary/relators/dln	dln	delineator
-http://id.loc.gov/vocabulary/relators/dnc	dnc	dancer
-http://id.loc.gov/vocabulary/relators/dnr	dnr	donor
+http://id.loc.gov/vocabulary/relators/dnc	dnc	dancer	Dancer	Tänzer/in
+http://id.loc.gov/vocabulary/relators/dnr	dnr	donor	Donor	Stifter/in
 http://id.loc.gov/vocabulary/relators/dpc	dpc	depicted
-http://id.loc.gov/vocabulary/relators/dpt	dpt	depositor
-http://id.loc.gov/vocabulary/relators/drm	drm	draftsman
-http://id.loc.gov/vocabulary/relators/drt	drt	director
-http://id.loc.gov/vocabulary/relators/dsr	dsr	designer
-http://id.loc.gov/vocabulary/relators/dst	dst	distributor
+http://id.loc.gov/vocabulary/relators/dpt	dpt	depositor	Depositor	Leihgabe von
+http://id.loc.gov/vocabulary/relators/drm	drm	draftsman	Draftsman	Technische Zeichnungen
+http://id.loc.gov/vocabulary/relators/drt	drt	director	Director	Regie
+http://id.loc.gov/vocabulary/relators/dsr	dsr	designer	Designer	Design
+http://id.loc.gov/vocabulary/relators/dst	dst	distributor	Distributor	Vertrieb
 http://id.loc.gov/vocabulary/relators/dtc	dtc	data contributor
-http://id.loc.gov/vocabulary/relators/dte	dte	dedicatee
+http://id.loc.gov/vocabulary/relators/dte	dte	dedicatee	Dedicatee	Gewidmet
 http://id.loc.gov/vocabulary/relators/dtm	dtm	data manager
-http://id.loc.gov/vocabulary/relators/dto	dto	dedicator
+http://id.loc.gov/vocabulary/relators/dto	dto	dedicator	Dedicator	Widmende/r
 http://id.loc.gov/vocabulary/relators/dub	dub	dubious author
 http://id.loc.gov/vocabulary/relators/edc	edc	editor of compilation
 http://id.loc.gov/vocabulary/relators/edd	edd	editorial director
-http://id.loc.gov/vocabulary/relators/edm	edm	editor of moving image work
-http://id.loc.gov/vocabulary/relators/edt	edt	editor
-http://id.loc.gov/vocabulary/relators/egr	egr	engraver
+http://id.loc.gov/vocabulary/relators/edm	edm	editor of moving image work	Editor of moving image work	Schnitt
+http://id.loc.gov/vocabulary/relators/edt	edt	editor	Editor	Herausgeber/in
+http://id.loc.gov/vocabulary/relators/egr	egr	engraver	Engraver	Stecher/in
 http://id.loc.gov/vocabulary/relators/elg	elg	electrician
 http://id.loc.gov/vocabulary/relators/elt	elt	electrotyper
 http://id.loc.gov/vocabulary/relators/eng	eng	engineer
-http://id.loc.gov/vocabulary/relators/enj	enj	enacting jurisdiction
-http://id.loc.gov/vocabulary/relators/etr	etr	etcher
+http://id.loc.gov/vocabulary/relators/enj	enj	enacting jurisdiction	Enacting jurisdiction	Normerlassende Gebietskörperschaft
+http://id.loc.gov/vocabulary/relators/etr	etr	etcher	Etcher	Radierer/in
 http://id.loc.gov/vocabulary/relators/evp	evp	event place
 http://id.loc.gov/vocabulary/relators/exp	exp	expert
 http://id.loc.gov/vocabulary/relators/fac	fac	facsimilist
-http://id.loc.gov/vocabulary/relators/fds	fds	film distributor
+http://id.loc.gov/vocabulary/relators/fds	fds	film distributor	Film distributor	Filmvertrieb
 http://id.loc.gov/vocabulary/relators/fld	fld	field director
 http://id.loc.gov/vocabulary/relators/flm	flm	film editor
-http://id.loc.gov/vocabulary/relators/fmd	fmd	film director
-http://id.loc.gov/vocabulary/relators/fmk	fmk	filmmaker
-http://id.loc.gov/vocabulary/relators/fmo	fmo	former owner
-http://id.loc.gov/vocabulary/relators/fmp	fmp	film producer
+http://id.loc.gov/vocabulary/relators/fmd	fmd	film director	Film director	Filmregie
+http://id.loc.gov/vocabulary/relators/fmk	fmk	filmmaker	Filmmaker	Filmemacher/in
+http://id.loc.gov/vocabulary/relators/fmo	fmo	former owner	Former owner	frühere/r Eigentümer/in
+http://id.loc.gov/vocabulary/relators/fmp	fmp	film producer	Film producer	Filmproduktion
 http://id.loc.gov/vocabulary/relators/fnd	fnd	funder
 http://id.loc.gov/vocabulary/relators/fon	fon	founder
 http://id.loc.gov/vocabulary/relators/fpy	fpy	first party
@@ -139,139 +139,139 @@ http://id.loc.gov/vocabulary/relators/gdv	gdv	game developer
 http://id.loc.gov/vocabulary/relators/gis	gis	geographic information specialist
 http://id.loc.gov/vocabulary/relators/grt	grt	graphic technician
 http://id.loc.gov/vocabulary/relators/gst	gst	guest
-http://id.loc.gov/vocabulary/relators/his	his	host institution
-http://id.loc.gov/vocabulary/relators/hnr	hnr	honoree
-http://id.loc.gov/vocabulary/relators/hst	hst	host
-http://id.loc.gov/vocabulary/relators/ill	ill	illustrator
-http://id.loc.gov/vocabulary/relators/ilu	ilu	illuminator
+http://id.loc.gov/vocabulary/relators/his	his	host institution	Host institution	Gastgebende Institution
+http://id.loc.gov/vocabulary/relators/hnr	hnr	honoree	Honouree	Gefeierte Person
+http://id.loc.gov/vocabulary/relators/hst	hst	host	Host	Gastgeber/in
+http://id.loc.gov/vocabulary/relators/ill	ill	illustrator	Illustrator	Illustration
+http://id.loc.gov/vocabulary/relators/ilu	ilu	illuminator	Illuminator	Illuminator/in
 http://id.loc.gov/vocabulary/relators/ink	ink	inker
-http://id.loc.gov/vocabulary/relators/ins	ins	inscriber
-http://id.loc.gov/vocabulary/relators/inv	inv	inventor
-http://id.loc.gov/vocabulary/relators/isb	isb	issuing body
-http://id.loc.gov/vocabulary/relators/itr	itr	instrumentalist
-http://id.loc.gov/vocabulary/relators/ive	ive	interviewee
-http://id.loc.gov/vocabulary/relators/ivr	ivr	interviewer
-http://id.loc.gov/vocabulary/relators/jud	jud	judge
-http://id.loc.gov/vocabulary/relators/jug	jug	jurisdiction governed
+http://id.loc.gov/vocabulary/relators/ins	ins	inscriber	Inscriber	Beschriftende Person
+http://id.loc.gov/vocabulary/relators/inv	inv	inventor	Inventor	Erfinder/in
+http://id.loc.gov/vocabulary/relators/isb	isb	issuing body	Issuing body	Herausgeber/in
+http://id.loc.gov/vocabulary/relators/itr	itr	instrumentalist	Instrumentalist	Instrumentalmusiker/in
+http://id.loc.gov/vocabulary/relators/ive	ive	interviewee	Interviewee	Interviewte/r
+http://id.loc.gov/vocabulary/relators/ivr	ivr	interviewer	Interviewer	Interviewer/in
+http://id.loc.gov/vocabulary/relators/jud	jud	judge	Judge	Richter/in
+http://id.loc.gov/vocabulary/relators/jug	jug	jurisdiction governed	Jurisdiction governed	Geregelte Gebietskörperschaft
 http://id.loc.gov/vocabulary/relators/lbr	lbr	laboratory
-http://id.loc.gov/vocabulary/relators/lbt	lbt	librettist
+http://id.loc.gov/vocabulary/relators/lbt	lbt	librettist	Librettist	Libretto
 http://id.loc.gov/vocabulary/relators/ldr	ldr	laboratory director
-http://id.loc.gov/vocabulary/relators/led	led	lead
+http://id.loc.gov/vocabulary/relators/led	led	lead	Lead	Leitung
 http://id.loc.gov/vocabulary/relators/lee	lee	libelee-appellee
 http://id.loc.gov/vocabulary/relators/lel	lel	libelee
 http://id.loc.gov/vocabulary/relators/len	len	lender
 http://id.loc.gov/vocabulary/relators/let	let	libelee-appellant
-http://id.loc.gov/vocabulary/relators/lgd	lgd	lighting designer
+http://id.loc.gov/vocabulary/relators/lgd	lgd	lighting designer	Lighting designer	Lichtgestaltung
 http://id.loc.gov/vocabulary/relators/lie	lie	libelant-appellee
 http://id.loc.gov/vocabulary/relators/lil	lil	libelant
 http://id.loc.gov/vocabulary/relators/lit	lit	libelant-appellant
-http://id.loc.gov/vocabulary/relators/lsa	lsa	landscape architect
+http://id.loc.gov/vocabulary/relators/lsa	lsa	landscape architect	Landscape architect	Landschaftsarchitekt/in
 http://id.loc.gov/vocabulary/relators/lse	lse	licensee
 http://id.loc.gov/vocabulary/relators/lso	lso	licensor
-http://id.loc.gov/vocabulary/relators/ltg	ltg	lithographer
+http://id.loc.gov/vocabulary/relators/ltg	ltg	lithographer	Lithographer	Lithografie
 http://id.loc.gov/vocabulary/relators/ltr	ltr	letterer
-http://id.loc.gov/vocabulary/relators/lyr	lyr	lyricist
+http://id.loc.gov/vocabulary/relators/lyr	lyr	lyricist	Lyricist	Textdichter/in
 http://id.loc.gov/vocabulary/relators/mcp	mcp	music copyist
 http://id.loc.gov/vocabulary/relators/mdc	mdc	metadata contact
-http://id.loc.gov/vocabulary/relators/med	med	medium
+http://id.loc.gov/vocabulary/relators/med	med	medium	Medium	Medium
 http://id.loc.gov/vocabulary/relators/mfp	mfp	manufacture place
-http://id.loc.gov/vocabulary/relators/mfr	mfr	manufacturer
+http://id.loc.gov/vocabulary/relators/mfr	mfr	manufacturer	Manufacturer	Herstellung
 http://id.loc.gov/vocabulary/relators/mka	mka	makeup artist
-http://id.loc.gov/vocabulary/relators/mod	mod	moderator
+http://id.loc.gov/vocabulary/relators/mod	mod	moderator	Moderator	Moderation
 http://id.loc.gov/vocabulary/relators/mon	mon	monitor
 http://id.loc.gov/vocabulary/relators/mrb	mrb	marbler
 http://id.loc.gov/vocabulary/relators/mrk	mrk	markup editor
-http://id.loc.gov/vocabulary/relators/msd	msd	musical director
+http://id.loc.gov/vocabulary/relators/msd	msd	musical director	Musical director	Musikalische Leitung
 http://id.loc.gov/vocabulary/relators/mte	mte	metal engraver
-http://id.loc.gov/vocabulary/relators/mtk	mtk	minute taker
+http://id.loc.gov/vocabulary/relators/mtk	mtk	minute taker	Minute taker	Protokoll
 http://id.loc.gov/vocabulary/relators/mup	mup	music programmer
-http://id.loc.gov/vocabulary/relators/mus	mus	musician
+http://id.loc.gov/vocabulary/relators/mus	mus	musician	Musician	Musiker/in
 http://id.loc.gov/vocabulary/relators/mxe	mxe	mixing engineer
 http://id.loc.gov/vocabulary/relators/nan	nan	news anchor
-http://id.loc.gov/vocabulary/relators/nrt	nrt	narrator
+http://id.loc.gov/vocabulary/relators/nrt	nrt	narrator	Narrator	Erzähler/in
 http://id.loc.gov/vocabulary/relators/onp	onp	onscreen participant
 http://id.loc.gov/vocabulary/relators/opn	opn	opponent
-http://id.loc.gov/vocabulary/relators/org	org	originator
-http://id.loc.gov/vocabulary/relators/orm	orm	organizer
-http://id.loc.gov/vocabulary/relators/osp	osp	onscreen presenter
-http://id.loc.gov/vocabulary/relators/oth	oth	other
-http://id.loc.gov/vocabulary/relators/own	own	owner
+http://id.loc.gov/vocabulary/relators/org	org	originator	Originator	Begründet durch
+http://id.loc.gov/vocabulary/relators/orm	orm	organizer	Organizer	Veranstalter/in
+http://id.loc.gov/vocabulary/relators/osp	osp	onscreen presenter	On-screen presenter	On-Screen-Präsentator/in
+http://id.loc.gov/vocabulary/relators/oth	oth	other	Other agent associated with a work	Sonstige
+http://id.loc.gov/vocabulary/relators/own	own	owner	Owner	Eigentümer/in
 http://id.loc.gov/vocabulary/relators/pad	pad	place of address
-http://id.loc.gov/vocabulary/relators/pan	pan	panelist
-http://id.loc.gov/vocabulary/relators/pat	pat	patron
-http://id.loc.gov/vocabulary/relators/pbd	pbd	publisher director
-http://id.loc.gov/vocabulary/relators/pbl	pbl	publisher
+http://id.loc.gov/vocabulary/relators/pan	pan	panelist	Panelist	Diskussionsteilnehmer/in
+http://id.loc.gov/vocabulary/relators/pat	pat	patron	Commissioning body	Im Auftrag von
+http://id.loc.gov/vocabulary/relators/pbd	pbd	publisher director	Editorial director	Chefredaktion
+http://id.loc.gov/vocabulary/relators/pbl	pbl	publisher	Publisher	Verlag
 http://id.loc.gov/vocabulary/relators/pdr	pdr	project director
 http://id.loc.gov/vocabulary/relators/pfr	pfr	proofreader
-http://id.loc.gov/vocabulary/relators/pht	pht	photographer
-http://id.loc.gov/vocabulary/relators/plt	plt	platemaker
+http://id.loc.gov/vocabulary/relators/pht	pht	photographer	Photographer	Fotografie
+http://id.loc.gov/vocabulary/relators/plt	plt	platemaker	Platemaker	Druckformherstellung
 http://id.loc.gov/vocabulary/relators/pma	pma	permitting agency
 http://id.loc.gov/vocabulary/relators/pmn	pmn	production manager
 http://id.loc.gov/vocabulary/relators/pnc	pnc	penciller
 http://id.loc.gov/vocabulary/relators/pop	pop	printer of plates
-http://id.loc.gov/vocabulary/relators/ppm	ppm	papermaker
-http://id.loc.gov/vocabulary/relators/ppt	ppt	puppeteer
-http://id.loc.gov/vocabulary/relators/pra	pra	praeses
+http://id.loc.gov/vocabulary/relators/ppm	ppm	papermaker	Papermaker	Papiermacher/in
+http://id.loc.gov/vocabulary/relators/ppt	ppt	puppeteer	Puppeteer	Puppenspieler/in
+http://id.loc.gov/vocabulary/relators/pra	pra	praeses	Praeses	Praeses
 http://id.loc.gov/vocabulary/relators/prc	prc	process contact
 http://id.loc.gov/vocabulary/relators/prd	prd	production personnel
-http://id.loc.gov/vocabulary/relators/pre	pre	presenter
-http://id.loc.gov/vocabulary/relators/prf	prf	performer
-http://id.loc.gov/vocabulary/relators/prg	prg	programmer
-http://id.loc.gov/vocabulary/relators/prm	prm	printmaker
-http://id.loc.gov/vocabulary/relators/prn	prn	production company
-http://id.loc.gov/vocabulary/relators/pro	pro	producer
+http://id.loc.gov/vocabulary/relators/pre	pre	presenter	Presenter	Präsentation
+http://id.loc.gov/vocabulary/relators/prf	prf	performer	Performer	Ausführende/r
+http://id.loc.gov/vocabulary/relators/prg	prg	programmer	Programmer	Programmiererung
+http://id.loc.gov/vocabulary/relators/prm	prm	printmaker	Printmaker	Druckgrafik
+http://id.loc.gov/vocabulary/relators/prn	prn	production company	Production company	Produktionsfirma
+http://id.loc.gov/vocabulary/relators/pro	pro	producer	Producer	Produktion
 http://id.loc.gov/vocabulary/relators/prp	prp	production place
-http://id.loc.gov/vocabulary/relators/prs	prs	production designer
-http://id.loc.gov/vocabulary/relators/prt	prt	printer
+http://id.loc.gov/vocabulary/relators/prs	prs	production designer	Production designer	Produktionsdesign
+http://id.loc.gov/vocabulary/relators/prt	prt	printer	Printer	Druck
 http://id.loc.gov/vocabulary/relators/prv	prv	provider
 http://id.loc.gov/vocabulary/relators/pta	pta	patent applicant
 http://id.loc.gov/vocabulary/relators/pte	pte	plaintiff-appellee
-http://id.loc.gov/vocabulary/relators/ptf	ptf	plaintiff
+http://id.loc.gov/vocabulary/relators/ptf	ptf	plaintiff	Plaintiff	Zivilkläger/in
 http://id.loc.gov/vocabulary/relators/pth	pth	patent holder
 http://id.loc.gov/vocabulary/relators/ptt	ptt	plaintiff-appellant
 http://id.loc.gov/vocabulary/relators/pup	pup	publication place
 http://id.loc.gov/vocabulary/relators/rap	rap	rapporteur
 http://id.loc.gov/vocabulary/relators/rbr	rbr	rubricator
-http://id.loc.gov/vocabulary/relators/rcd	rcd	recordist
-http://id.loc.gov/vocabulary/relators/rce	rce	recording engineer
-http://id.loc.gov/vocabulary/relators/rcp	rcp	addressee
-http://id.loc.gov/vocabulary/relators/rdd	rdd	radio director
-http://id.loc.gov/vocabulary/relators/red	red	redaktor
+http://id.loc.gov/vocabulary/relators/rcd	rcd	recordist	Recordist	Ton
+http://id.loc.gov/vocabulary/relators/rce	rce	recording engineer	Recording engineer	Aufnahmetechniker/in
+http://id.loc.gov/vocabulary/relators/rcp	rcp	addressee	Addressee	Adressat/in
+http://id.loc.gov/vocabulary/relators/rdd	rdd	radio director	Radio director	Hörfunkregisseur/in
+http://id.loc.gov/vocabulary/relators/red	red	redaktor	Redaktor	Redaktion
 http://id.loc.gov/vocabulary/relators/ren	ren	renderer
-http://id.loc.gov/vocabulary/relators/res	res	researcher
+http://id.loc.gov/vocabulary/relators/res	res	researcher	Researcher	Forscher/in
 http://id.loc.gov/vocabulary/relators/rev	rev	reviewer
-http://id.loc.gov/vocabulary/relators/rpc	rpc	radio producer
+http://id.loc.gov/vocabulary/relators/rpc	rpc	radio producer	Radio producer	Hörfunkproduktion
 http://id.loc.gov/vocabulary/relators/rps	rps	repository
 http://id.loc.gov/vocabulary/relators/rpt	rpt	reporter
 http://id.loc.gov/vocabulary/relators/rpy	rpy	responsible party
 http://id.loc.gov/vocabulary/relators/rse	rse	respondent-appellee
 http://id.loc.gov/vocabulary/relators/rsg	rsg	restager
-http://id.loc.gov/vocabulary/relators/rsp	rsp	respondent
-http://id.loc.gov/vocabulary/relators/rsr	rsr	restorationist
+http://id.loc.gov/vocabulary/relators/rsp	rsp	respondent	Respondent	Respondent/in
+http://id.loc.gov/vocabulary/relators/rsr	rsr	restorationist	Restorationist	Restaurator/in
 http://id.loc.gov/vocabulary/relators/rst	rst	respondent-appellant
 http://id.loc.gov/vocabulary/relators/rth	rth	research team head
 http://id.loc.gov/vocabulary/relators/rtm	rtm	research team member
 http://id.loc.gov/vocabulary/relators/rxa	rxa	remix artist
 http://id.loc.gov/vocabulary/relators/sad	sad	scientific advisor
 http://id.loc.gov/vocabulary/relators/sce	sce	scenarist
-http://id.loc.gov/vocabulary/relators/scl	scl	sculptor
+http://id.loc.gov/vocabulary/relators/scl	scl	sculptor	Sculptor	Bildhauer/in
 http://id.loc.gov/vocabulary/relators/scr	scr	scribe
 http://id.loc.gov/vocabulary/relators/sde	sde	sound engineer
-http://id.loc.gov/vocabulary/relators/sds	sds	sound designer
+http://id.loc.gov/vocabulary/relators/sds	sds	sound designer	Sound designer	Tongestaltung
 http://id.loc.gov/vocabulary/relators/sec	sec	secretary
 http://id.loc.gov/vocabulary/relators/sfx	sfx	special effects provider
-http://id.loc.gov/vocabulary/relators/sgd	sgd	stage director
+http://id.loc.gov/vocabulary/relators/sgd	sgd	stage director	Stage director	Bühnenregie
 http://id.loc.gov/vocabulary/relators/sgn	sgn	signer
 http://id.loc.gov/vocabulary/relators/sht	sht	supporting host
-http://id.loc.gov/vocabulary/relators/sll	sll	seller
-http://id.loc.gov/vocabulary/relators/sng	sng	singer
-http://id.loc.gov/vocabulary/relators/spk	spk	speaker
-http://id.loc.gov/vocabulary/relators/spn	spn	sponsor
+http://id.loc.gov/vocabulary/relators/sll	sll	seller	Seller	Verkäufer/in
+http://id.loc.gov/vocabulary/relators/sng	sng	singer	Singer	Gesang
+http://id.loc.gov/vocabulary/relators/spk	spk	speaker	Speaker	Redner/in
+http://id.loc.gov/vocabulary/relators/spn	spn	sponsor	Sponsoring body	Träger/in
 http://id.loc.gov/vocabulary/relators/spy	spy	second party
-http://id.loc.gov/vocabulary/relators/srv	srv	surveyor
+http://id.loc.gov/vocabulary/relators/srv	srv	surveyor	Surveyor	Landvermessung
 http://id.loc.gov/vocabulary/relators/std	std	set designer
 http://id.loc.gov/vocabulary/relators/stg	stg	setting
-http://id.loc.gov/vocabulary/relators/stl	stl	storyteller
+http://id.loc.gov/vocabulary/relators/stl	stl	storyteller	Storyteller	Geschichtenerzähler/in
 http://id.loc.gov/vocabulary/relators/stm	stm	stage manager
 http://id.loc.gov/vocabulary/relators/stn	stn	standards body
 http://id.loc.gov/vocabulary/relators/str	str	stereotyper
@@ -279,33 +279,33 @@ http://id.loc.gov/vocabulary/relators/swd	swd	software developer
 http://id.loc.gov/vocabulary/relators/tad	tad	technical advisor
 http://id.loc.gov/vocabulary/relators/tau	tau	television writer
 http://id.loc.gov/vocabulary/relators/tcd	tcd	technical director
-http://id.loc.gov/vocabulary/relators/tch	tch	teacher
+http://id.loc.gov/vocabulary/relators/tch	tch	teacher	Teacher	Ausbilder/in
 http://id.loc.gov/vocabulary/relators/ths	ths	thesis advisor
-http://id.loc.gov/vocabulary/relators/tld	tld	television director
+http://id.loc.gov/vocabulary/relators/tld	tld	television director	Television director	Fernsehregie
 http://id.loc.gov/vocabulary/relators/tlg	tlg	television guest
 http://id.loc.gov/vocabulary/relators/tlh	tlh	television host
-http://id.loc.gov/vocabulary/relators/tlp	tlp	television producer
-http://id.loc.gov/vocabulary/relators/trc	trc	transcriber
-http://id.loc.gov/vocabulary/relators/trl	trl	translator
+http://id.loc.gov/vocabulary/relators/tlp	tlp	television producer	Television producer	Fernsehproduktion
+http://id.loc.gov/vocabulary/relators/trc	trc	transcriber	Transcriber	Transkription
+http://id.loc.gov/vocabulary/relators/trl	trl	translator	Translator	Übersetzung
 http://id.loc.gov/vocabulary/relators/tyd	tyd	type designer
 http://id.loc.gov/vocabulary/relators/tyg	tyg	typographer
 http://id.loc.gov/vocabulary/relators/uvp	uvp	university place
-http://id.loc.gov/vocabulary/relators/vac	vac	voice actor
-http://id.loc.gov/vocabulary/relators/vdg	vdg	videographer
+http://id.loc.gov/vocabulary/relators/vac	vac	voice actor	Voice actor	Synchronsprecher/in
+http://id.loc.gov/vocabulary/relators/vdg	vdg	videographer	Director of photography	Kamera
 http://id.loc.gov/vocabulary/relators/vfx	vfx	visual effects provider
 http://id.loc.gov/vocabulary/relators/voc	voc	vocalist
-http://id.loc.gov/vocabulary/relators/wac	wac	writer of added commentary
-http://id.loc.gov/vocabulary/relators/wal	wal	writer of added lyrics
+http://id.loc.gov/vocabulary/relators/wac	wac	writer of added commentary	Writer of added commentary	Zusätzlicher Kommentar
+http://id.loc.gov/vocabulary/relators/wal	wal	writer of added lyrics	Writer of added lyrics	Verfasser/in von zusätzlichen Lyrics
 http://id.loc.gov/vocabulary/relators/wam	wam	writer of accompanying material
-http://id.loc.gov/vocabulary/relators/wat	wat	writer of added text
+http://id.loc.gov/vocabulary/relators/wat	wat	writer of added text	Writer of added text	Zusätzlicher Text
 http://id.loc.gov/vocabulary/relators/waw	waw	writer of afterword
 http://id.loc.gov/vocabulary/relators/wdc	wdc	woodcutter
 http://id.loc.gov/vocabulary/relators/wde	wde	wood engraver
 http://id.loc.gov/vocabulary/relators/wfs	wfs	writer of film story
 http://id.loc.gov/vocabulary/relators/wft	wft	writer of intertitles
 http://id.loc.gov/vocabulary/relators/wfw	wfw	writer of foreword
-http://id.loc.gov/vocabulary/relators/win	win	writer of introduction
+http://id.loc.gov/vocabulary/relators/win	win	writer of introduction	Writer of introduction	Einleitung
 http://id.loc.gov/vocabulary/relators/wit	wit	witness
-http://id.loc.gov/vocabulary/relators/wpr	wpr	writer of preface
-http://id.loc.gov/vocabulary/relators/wst	wst	writer of supplementary textual content
+http://id.loc.gov/vocabulary/relators/wpr	wpr	writer of preface	Writer of preface	Vorwort
+http://id.loc.gov/vocabulary/relators/wst	wst	writer of supplementary textual content	Writer of supplementary textual content	Verfasser/in von ergänzendem Text
 http://id.loc.gov/vocabulary/relators/wts	wts	writer of television story

--- a/data/marc-relators.tsv
+++ b/data/marc-relators.tsv
@@ -1,150 +1,150 @@
 uri	code	term	label@en	label@de
 http://id.loc.gov/vocabulary/relators/abr	abr	abridger	Abridger	Kürzende/r
-http://id.loc.gov/vocabulary/relators/acp	acp	art copyist
+http://id.loc.gov/vocabulary/relators/acp	acp	art copyist	Art copyist
 http://id.loc.gov/vocabulary/relators/act	act	actor	Actor	Schauspieler/in
 http://id.loc.gov/vocabulary/relators/adi	adi	art director	Art director	Art Director
-http://id.loc.gov/vocabulary/relators/adp	adp	adapter
-http://id.loc.gov/vocabulary/relators/afd	afd	assistant film director
+http://id.loc.gov/vocabulary/relators/adp	adp	adapter	Adapter
+http://id.loc.gov/vocabulary/relators/afd	afd	assistant film director	Assistant film director
 http://id.loc.gov/vocabulary/relators/aft	aft	author of afterword, colophon, etc.	Writer of afterword	Verfasser/in eines Nachworts
-http://id.loc.gov/vocabulary/relators/anc	anc	announcer
-http://id.loc.gov/vocabulary/relators/anl	anl	analyst
+http://id.loc.gov/vocabulary/relators/anc	anc	announcer	Announcer
+http://id.loc.gov/vocabulary/relators/anl	anl	analyst	Analyst
 http://id.loc.gov/vocabulary/relators/anm	anm	animator	Animator	Animation
 http://id.loc.gov/vocabulary/relators/ann	ann	annotator	Annotator	Annotationen
 http://id.loc.gov/vocabulary/relators/ant	ant	bibliographic antecedent	Bibliographic antecedent	Basiert auf einem Werk von
-http://id.loc.gov/vocabulary/relators/apb	apb	approbator
+http://id.loc.gov/vocabulary/relators/apb	apb	approbator	Approbator
 http://id.loc.gov/vocabulary/relators/ape	ape	appellee	Appellee	Berufungsbeklagte/r / Revisionsbeklagte/r
 http://id.loc.gov/vocabulary/relators/apl	apl	appellant	Appellant	Berufungskläger/in / Revisionskläger/in
-http://id.loc.gov/vocabulary/relators/app	app	applicant
-http://id.loc.gov/vocabulary/relators/aqt	aqt	author in quotations or text abstracts
+http://id.loc.gov/vocabulary/relators/app	app	applicant	Applicant
+http://id.loc.gov/vocabulary/relators/aqt	aqt	author in quotations or text abstracts	Author in quotations or text abstracts
 http://id.loc.gov/vocabulary/relators/arc	arc	architect	Architect	Architekt/in
-http://id.loc.gov/vocabulary/relators/ard	ard	artistic director
+http://id.loc.gov/vocabulary/relators/ard	ard	artistic director	Artistic director
 http://id.loc.gov/vocabulary/relators/arr	arr	arranger	Arranger of music	Arrangement
 http://id.loc.gov/vocabulary/relators/art	art	artist	Artist	Künstler/in
-http://id.loc.gov/vocabulary/relators/asg	asg	assignee
-http://id.loc.gov/vocabulary/relators/asn	asn	associated name
+http://id.loc.gov/vocabulary/relators/asg	asg	assignee	Assignee
+http://id.loc.gov/vocabulary/relators/asn	asn	associated name	Associated name
 http://id.loc.gov/vocabulary/relators/ato	ato	autographer	Autographer	Unterzeichner/in
-http://id.loc.gov/vocabulary/relators/att	att	attributed name
-http://id.loc.gov/vocabulary/relators/auc	auc	auctioneer
-http://id.loc.gov/vocabulary/relators/aud	aud	author of dialog
-http://id.loc.gov/vocabulary/relators/aue	aue	audio engineer
+http://id.loc.gov/vocabulary/relators/att	att	attributed name	Attributed name
+http://id.loc.gov/vocabulary/relators/auc	auc	auctioneer	Auctioneer
+http://id.loc.gov/vocabulary/relators/aud	aud	author of dialog	Author of dialog
+http://id.loc.gov/vocabulary/relators/aue	aue	audio engineer	Audio engineer
 http://id.loc.gov/vocabulary/relators/aui	aui	author of introduction, etc.	Writer of foreword	Vorwort
-http://id.loc.gov/vocabulary/relators/aup	aup	audio producer
+http://id.loc.gov/vocabulary/relators/aup	aup	audio producer	Audio producer
 http://id.loc.gov/vocabulary/relators/aus	aus	screenwriter	Screenwriter	Drehbuch
 http://id.loc.gov/vocabulary/relators/aut	aut	author	Author	Autor/in
-http://id.loc.gov/vocabulary/relators/bdd	bdd	binding designer
-http://id.loc.gov/vocabulary/relators/bjd	bjd	bookjacket designer
-http://id.loc.gov/vocabulary/relators/bka	bka	book artist
+http://id.loc.gov/vocabulary/relators/bdd	bdd	binding designer	Binding designer
+http://id.loc.gov/vocabulary/relators/bjd	bjd	bookjacket designer	Bookjacket designer
+http://id.loc.gov/vocabulary/relators/bka	bka	book artist	Book artist
 http://id.loc.gov/vocabulary/relators/bkd	bkd	book designer	Book designer	Buchgestaltung
-http://id.loc.gov/vocabulary/relators/bkp	bkp	book producer
-http://id.loc.gov/vocabulary/relators/blw	blw	blurb writer
+http://id.loc.gov/vocabulary/relators/bkp	bkp	book producer	Book producer
+http://id.loc.gov/vocabulary/relators/blw	blw	blurb writer	Blurb writer
 http://id.loc.gov/vocabulary/relators/bnd	bnd	binder	Binder	Buchbinder/in
-http://id.loc.gov/vocabulary/relators/bpd	bpd	bookplate designer
+http://id.loc.gov/vocabulary/relators/bpd	bpd	bookplate designer	Bookplate designer
 http://id.loc.gov/vocabulary/relators/brd	brd	broadcaster	Broadcaster	Sender
 http://id.loc.gov/vocabulary/relators/brl	brl	braille embosser	Braille embosser	Brailleprägung
-http://id.loc.gov/vocabulary/relators/bsl	bsl	bookseller
-http://id.loc.gov/vocabulary/relators/cad	cad	casting director
+http://id.loc.gov/vocabulary/relators/bsl	bsl	bookseller	Bookseller
+http://id.loc.gov/vocabulary/relators/cad	cad	casting director	Casting director
 http://id.loc.gov/vocabulary/relators/cas	cas	caster	Caster	Formguss
-http://id.loc.gov/vocabulary/relators/ccp	ccp	conceptor
+http://id.loc.gov/vocabulary/relators/ccp	ccp	conceptor	Conceptor
 http://id.loc.gov/vocabulary/relators/chr	chr	choreographer	Choreographer	Choreographie
 http://id.loc.gov/vocabulary/relators/clb	clb	collaborator	Collaborator	Mitarbeit
-http://id.loc.gov/vocabulary/relators/cli	cli	client
+http://id.loc.gov/vocabulary/relators/cli	cli	client	Client
 http://id.loc.gov/vocabulary/relators/cll	cll	calligrapher	Calligrapher	Kalligrafie
 http://id.loc.gov/vocabulary/relators/clr	clr	colorist	Colourist	Kolorierung
 http://id.loc.gov/vocabulary/relators/clt	clt	collotyper	Collotyper	Lichtdruck
 http://id.loc.gov/vocabulary/relators/cmm	cmm	commentator	Commentator	Kommentar
 http://id.loc.gov/vocabulary/relators/cmp	cmp	composer	Composer	Komposition
-http://id.loc.gov/vocabulary/relators/cmt	cmt	compositor
+http://id.loc.gov/vocabulary/relators/cmt	cmt	compositor	Compositor
 http://id.loc.gov/vocabulary/relators/cnd	cnd	conductor	Conductor	Dirigent/in / Leitung
 http://id.loc.gov/vocabulary/relators/cng	cng	cinematographer	Cinematographer	Kamera
 http://id.loc.gov/vocabulary/relators/cns	cns	censor	Censor	Zensor/in
-http://id.loc.gov/vocabulary/relators/coe	coe	contestant-appellee
+http://id.loc.gov/vocabulary/relators/coe	coe	contestant-appellee	Contestant-appellee
 http://id.loc.gov/vocabulary/relators/col	col	collector	Collector	Sammler/in
 http://id.loc.gov/vocabulary/relators/com	com	compiler	Compiler	Zusammengestellt von
-http://id.loc.gov/vocabulary/relators/con	con	conservator
-http://id.loc.gov/vocabulary/relators/cop	cop	camera operator
+http://id.loc.gov/vocabulary/relators/con	con	conservator	Conservator
+http://id.loc.gov/vocabulary/relators/cop	cop	camera operator	Camera operator
 http://id.loc.gov/vocabulary/relators/cor	cor	collection registrar	Collection registrar	Registrar/in
-http://id.loc.gov/vocabulary/relators/cos	cos	contestant
-http://id.loc.gov/vocabulary/relators/cot	cot	contestant-appellant
+http://id.loc.gov/vocabulary/relators/cos	cos	contestant	Contestant
+http://id.loc.gov/vocabulary/relators/cot	cot	contestant-appellant	Contestant-appellant
 http://id.loc.gov/vocabulary/relators/cou	cou	court governed	Court governed	Durch Verfahrensvorschriften geregeltes Gericht
-http://id.loc.gov/vocabulary/relators/cov	cov	cover designer
-http://id.loc.gov/vocabulary/relators/cpc	cpc	copyright claimant
-http://id.loc.gov/vocabulary/relators/cpe	cpe	complainant-appellee
-http://id.loc.gov/vocabulary/relators/cph	cph	copyright holder
-http://id.loc.gov/vocabulary/relators/cpl	cpl	complainant
-http://id.loc.gov/vocabulary/relators/cpt	cpt	complainant-appellant
+http://id.loc.gov/vocabulary/relators/cov	cov	cover designer	Cover designer
+http://id.loc.gov/vocabulary/relators/cpc	cpc	copyright claimant	Copyright claimant
+http://id.loc.gov/vocabulary/relators/cpe	cpe	complainant-appellee	Complainant-appellee
+http://id.loc.gov/vocabulary/relators/cph	cph	copyright holder	Copyright holder
+http://id.loc.gov/vocabulary/relators/cpl	cpl	complainant	Complainant
+http://id.loc.gov/vocabulary/relators/cpt	cpt	complainant-appellant	Complainant-appellant
 http://id.loc.gov/vocabulary/relators/cre	cre	creator	Creator	Schöpfer/in
-http://id.loc.gov/vocabulary/relators/crp	crp	correspondent
-http://id.loc.gov/vocabulary/relators/crr	crr	corrector
+http://id.loc.gov/vocabulary/relators/crp	crp	correspondent	Correspondent
+http://id.loc.gov/vocabulary/relators/crr	crr	corrector	Corrector
 http://id.loc.gov/vocabulary/relators/crt	crt	court reporter	Court reporter	Gerichtsstenograf/in
 http://id.loc.gov/vocabulary/relators/csl	csl	consultant	Consultant	Beratung
-http://id.loc.gov/vocabulary/relators/csp	csp	consultant to a project
+http://id.loc.gov/vocabulary/relators/csp	csp	consultant to a project	Consultant to a project
 http://id.loc.gov/vocabulary/relators/cst	cst	costume designer	Costume designer	Kostümdesign
 http://id.loc.gov/vocabulary/relators/ctb	ctb	contributor	Contributor	Beitragende/r
-http://id.loc.gov/vocabulary/relators/cte	cte	contestee-appellee
+http://id.loc.gov/vocabulary/relators/cte	cte	contestee-appellee	Contestee-appellee
 http://id.loc.gov/vocabulary/relators/ctg	ctg	cartographer	Cartographer	Kartografie
 http://id.loc.gov/vocabulary/relators/ctr	ctr	contractor	Participant in a treaty	Vertragspartner/in
-http://id.loc.gov/vocabulary/relators/cts	cts	contestee
-http://id.loc.gov/vocabulary/relators/ctt	ctt	contestee-appellant
+http://id.loc.gov/vocabulary/relators/cts	cts	contestee	Contestee
+http://id.loc.gov/vocabulary/relators/ctt	ctt	contestee-appellant	Contestee-appellant
 http://id.loc.gov/vocabulary/relators/cur	cur	curator	Curator	Kurator/in
-http://id.loc.gov/vocabulary/relators/cwt	cwt	commentator for written text
-http://id.loc.gov/vocabulary/relators/dbd	dbd	dubbing director
-http://id.loc.gov/vocabulary/relators/dbp	dbp	distribution place
+http://id.loc.gov/vocabulary/relators/cwt	cwt	commentator for written text	Commentator for written text
+http://id.loc.gov/vocabulary/relators/dbd	dbd	dubbing director	Dubbing director
+http://id.loc.gov/vocabulary/relators/dbp	dbp	distribution place	Distribution place
 http://id.loc.gov/vocabulary/relators/dfd	dfd	defendant	Defendant	Angeklagte/r
-http://id.loc.gov/vocabulary/relators/dfe	dfe	defendant-appellee
-http://id.loc.gov/vocabulary/relators/dft	dft	defendant-appellant
-http://id.loc.gov/vocabulary/relators/dgc	dgc	degree committee member
+http://id.loc.gov/vocabulary/relators/dfe	dfe	defendant-appellee	Defendant-appellee
+http://id.loc.gov/vocabulary/relators/dft	dft	defendant-appellant	Defendant-appellant
+http://id.loc.gov/vocabulary/relators/dgc	dgc	degree committee member	Degree committee member
 http://id.loc.gov/vocabulary/relators/dgg	dgg	degree granting institution	Degree granting institution	Grad-verleihende Institution
 http://id.loc.gov/vocabulary/relators/dgs	dgs	degree supervisor	Degree supervisor	Akademische Betreuung
-http://id.loc.gov/vocabulary/relators/dis	dis	dissertant
-http://id.loc.gov/vocabulary/relators/djo	djo	dj
-http://id.loc.gov/vocabulary/relators/dln	dln	delineator
+http://id.loc.gov/vocabulary/relators/dis	dis	dissertant	Dissertant
+http://id.loc.gov/vocabulary/relators/djo	djo	dj	DJ
+http://id.loc.gov/vocabulary/relators/dln	dln	delineator	Delineator
 http://id.loc.gov/vocabulary/relators/dnc	dnc	dancer	Dancer	Tänzer/in
 http://id.loc.gov/vocabulary/relators/dnr	dnr	donor	Donor	Stifter/in
-http://id.loc.gov/vocabulary/relators/dpc	dpc	depicted
+http://id.loc.gov/vocabulary/relators/dpc	dpc	depicted	Depicted
 http://id.loc.gov/vocabulary/relators/dpt	dpt	depositor	Depositor	Leihgabe von
 http://id.loc.gov/vocabulary/relators/drm	drm	draftsman	Draftsman	Technische Zeichnungen
 http://id.loc.gov/vocabulary/relators/drt	drt	director	Director	Regie
 http://id.loc.gov/vocabulary/relators/dsr	dsr	designer	Designer	Design
 http://id.loc.gov/vocabulary/relators/dst	dst	distributor	Distributor	Vertrieb
-http://id.loc.gov/vocabulary/relators/dtc	dtc	data contributor
+http://id.loc.gov/vocabulary/relators/dtc	dtc	data contributor	Data contributor
 http://id.loc.gov/vocabulary/relators/dte	dte	dedicatee	Dedicatee	Gewidmet
-http://id.loc.gov/vocabulary/relators/dtm	dtm	data manager
+http://id.loc.gov/vocabulary/relators/dtm	dtm	data manager	Data manager
 http://id.loc.gov/vocabulary/relators/dto	dto	dedicator	Dedicator	Widmende/r
-http://id.loc.gov/vocabulary/relators/dub	dub	dubious author
-http://id.loc.gov/vocabulary/relators/edc	edc	editor of compilation
-http://id.loc.gov/vocabulary/relators/edd	edd	editorial director
+http://id.loc.gov/vocabulary/relators/dub	dub	dubious author	Dubious author
+http://id.loc.gov/vocabulary/relators/edc	edc	editor of compilation	Editor of compilation
+http://id.loc.gov/vocabulary/relators/edd	edd	editorial director	Editorial director
 http://id.loc.gov/vocabulary/relators/edm	edm	editor of moving image work	Editor of moving image work	Schnitt
 http://id.loc.gov/vocabulary/relators/edt	edt	editor	Editor	Herausgeber/in
 http://id.loc.gov/vocabulary/relators/egr	egr	engraver	Engraver	Stecher/in
-http://id.loc.gov/vocabulary/relators/elg	elg	electrician
-http://id.loc.gov/vocabulary/relators/elt	elt	electrotyper
-http://id.loc.gov/vocabulary/relators/eng	eng	engineer
+http://id.loc.gov/vocabulary/relators/elg	elg	electrician	Electrician
+http://id.loc.gov/vocabulary/relators/elt	elt	electrotyper	Electrotyper
+http://id.loc.gov/vocabulary/relators/eng	eng	engineer	Engineer
 http://id.loc.gov/vocabulary/relators/enj	enj	enacting jurisdiction	Enacting jurisdiction	Normerlassende Gebietskörperschaft
 http://id.loc.gov/vocabulary/relators/etr	etr	etcher	Etcher	Radierer/in
-http://id.loc.gov/vocabulary/relators/evp	evp	event place
-http://id.loc.gov/vocabulary/relators/exp	exp	expert
-http://id.loc.gov/vocabulary/relators/fac	fac	facsimilist
+http://id.loc.gov/vocabulary/relators/evp	evp	event place	Event place
+http://id.loc.gov/vocabulary/relators/exp	exp	expert	Expert
+http://id.loc.gov/vocabulary/relators/fac	fac	facsimilist	Facsimilist
 http://id.loc.gov/vocabulary/relators/fds	fds	film distributor	Film distributor	Filmvertrieb
-http://id.loc.gov/vocabulary/relators/fld	fld	field director
-http://id.loc.gov/vocabulary/relators/flm	flm	film editor
+http://id.loc.gov/vocabulary/relators/fld	fld	field director	Field director
+http://id.loc.gov/vocabulary/relators/flm	flm	film editor	Film editor
 http://id.loc.gov/vocabulary/relators/fmd	fmd	film director	Film director	Filmregie
 http://id.loc.gov/vocabulary/relators/fmk	fmk	filmmaker	Filmmaker	Filmemacher/in
 http://id.loc.gov/vocabulary/relators/fmo	fmo	former owner	Former owner	frühere/r Eigentümer/in
 http://id.loc.gov/vocabulary/relators/fmp	fmp	film producer	Film producer	Filmproduktion
-http://id.loc.gov/vocabulary/relators/fnd	fnd	funder
-http://id.loc.gov/vocabulary/relators/fon	fon	founder
-http://id.loc.gov/vocabulary/relators/fpy	fpy	first party
-http://id.loc.gov/vocabulary/relators/frg	frg	forger
-http://id.loc.gov/vocabulary/relators/gdv	gdv	game developer
-http://id.loc.gov/vocabulary/relators/gis	gis	geographic information specialist
-http://id.loc.gov/vocabulary/relators/grt	grt	graphic technician
-http://id.loc.gov/vocabulary/relators/gst	gst	guest
+http://id.loc.gov/vocabulary/relators/fnd	fnd	funder	Funder
+http://id.loc.gov/vocabulary/relators/fon	fon	founder	Founder
+http://id.loc.gov/vocabulary/relators/fpy	fpy	first party	First party
+http://id.loc.gov/vocabulary/relators/frg	frg	forger	Forger
+http://id.loc.gov/vocabulary/relators/gdv	gdv	game developer	Game developer
+http://id.loc.gov/vocabulary/relators/gis	gis	geographic information specialist	Geographic information specialist
+http://id.loc.gov/vocabulary/relators/grt	grt	graphic technician	Graphic technician
+http://id.loc.gov/vocabulary/relators/gst	gst	guest	Guest
 http://id.loc.gov/vocabulary/relators/his	his	host institution	Host institution	Gastgebende Institution
 http://id.loc.gov/vocabulary/relators/hnr	hnr	honoree	Honouree	Gefeierte Person
 http://id.loc.gov/vocabulary/relators/hst	hst	host	Host	Gastgeber/in
 http://id.loc.gov/vocabulary/relators/ill	ill	illustrator	Illustrator	Illustration
 http://id.loc.gov/vocabulary/relators/ilu	ilu	illuminator	Illuminator	Illuminator/in
-http://id.loc.gov/vocabulary/relators/ink	ink	inker
+http://id.loc.gov/vocabulary/relators/ink	ink	inker	Inker
 http://id.loc.gov/vocabulary/relators/ins	ins	inscriber	Inscriber	Beschriftende Person
 http://id.loc.gov/vocabulary/relators/inv	inv	inventor	Inventor	Erfinder/in
 http://id.loc.gov/vocabulary/relators/isb	isb	issuing body	Issuing body	Herausgeber/in
@@ -153,159 +153,159 @@ http://id.loc.gov/vocabulary/relators/ive	ive	interviewee	Interviewee	Interviewt
 http://id.loc.gov/vocabulary/relators/ivr	ivr	interviewer	Interviewer	Interviewer/in
 http://id.loc.gov/vocabulary/relators/jud	jud	judge	Judge	Richter/in
 http://id.loc.gov/vocabulary/relators/jug	jug	jurisdiction governed	Jurisdiction governed	Geregelte Gebietskörperschaft
-http://id.loc.gov/vocabulary/relators/lbr	lbr	laboratory
+http://id.loc.gov/vocabulary/relators/lbr	lbr	laboratory	Laboratory
 http://id.loc.gov/vocabulary/relators/lbt	lbt	librettist	Librettist	Libretto
-http://id.loc.gov/vocabulary/relators/ldr	ldr	laboratory director
+http://id.loc.gov/vocabulary/relators/ldr	ldr	laboratory director	Laboratory director
 http://id.loc.gov/vocabulary/relators/led	led	lead	Lead	Leitung
-http://id.loc.gov/vocabulary/relators/lee	lee	libelee-appellee
-http://id.loc.gov/vocabulary/relators/lel	lel	libelee
-http://id.loc.gov/vocabulary/relators/len	len	lender
-http://id.loc.gov/vocabulary/relators/let	let	libelee-appellant
+http://id.loc.gov/vocabulary/relators/lee	lee	libelee-appellee	Libelee-appellee
+http://id.loc.gov/vocabulary/relators/lel	lel	libelee	Libelee
+http://id.loc.gov/vocabulary/relators/len	len	lender	Lender
+http://id.loc.gov/vocabulary/relators/let	let	libelee-appellant	Libelee-appellant
 http://id.loc.gov/vocabulary/relators/lgd	lgd	lighting designer	Lighting designer	Lichtgestaltung
-http://id.loc.gov/vocabulary/relators/lie	lie	libelant-appellee
-http://id.loc.gov/vocabulary/relators/lil	lil	libelant
-http://id.loc.gov/vocabulary/relators/lit	lit	libelant-appellant
+http://id.loc.gov/vocabulary/relators/lie	lie	libelant-appellee	Libelant-appellee
+http://id.loc.gov/vocabulary/relators/lil	lil	libelant	Libelant
+http://id.loc.gov/vocabulary/relators/lit	lit	libelant-appellant	Libelant-appellant
 http://id.loc.gov/vocabulary/relators/lsa	lsa	landscape architect	Landscape architect	Landschaftsarchitekt/in
-http://id.loc.gov/vocabulary/relators/lse	lse	licensee
-http://id.loc.gov/vocabulary/relators/lso	lso	licensor
+http://id.loc.gov/vocabulary/relators/lse	lse	licensee	Licensee
+http://id.loc.gov/vocabulary/relators/lso	lso	licensor	Licensor
 http://id.loc.gov/vocabulary/relators/ltg	ltg	lithographer	Lithographer	Lithografie
-http://id.loc.gov/vocabulary/relators/ltr	ltr	letterer
+http://id.loc.gov/vocabulary/relators/ltr	ltr	letterer	Letterer
 http://id.loc.gov/vocabulary/relators/lyr	lyr	lyricist	Lyricist	Textdichter/in
-http://id.loc.gov/vocabulary/relators/mcp	mcp	music copyist
-http://id.loc.gov/vocabulary/relators/mdc	mdc	metadata contact
+http://id.loc.gov/vocabulary/relators/mcp	mcp	music copyist	Music copyist
+http://id.loc.gov/vocabulary/relators/mdc	mdc	metadata contact	Metadata contact
 http://id.loc.gov/vocabulary/relators/med	med	medium	Medium	Medium
-http://id.loc.gov/vocabulary/relators/mfp	mfp	manufacture place
+http://id.loc.gov/vocabulary/relators/mfp	mfp	manufacture place	Manufacture place
 http://id.loc.gov/vocabulary/relators/mfr	mfr	manufacturer	Manufacturer	Herstellung
-http://id.loc.gov/vocabulary/relators/mka	mka	makeup artist
+http://id.loc.gov/vocabulary/relators/mka	mka	makeup artist	Makeup artist
 http://id.loc.gov/vocabulary/relators/mod	mod	moderator	Moderator	Moderation
-http://id.loc.gov/vocabulary/relators/mon	mon	monitor
-http://id.loc.gov/vocabulary/relators/mrb	mrb	marbler
-http://id.loc.gov/vocabulary/relators/mrk	mrk	markup editor
+http://id.loc.gov/vocabulary/relators/mon	mon	monitor	Monitor
+http://id.loc.gov/vocabulary/relators/mrb	mrb	marbler	Marbler
+http://id.loc.gov/vocabulary/relators/mrk	mrk	markup editor	Markup editor
 http://id.loc.gov/vocabulary/relators/msd	msd	musical director	Musical director	Musikalische Leitung
-http://id.loc.gov/vocabulary/relators/mte	mte	metal engraver
+http://id.loc.gov/vocabulary/relators/mte	mte	metal engraver	Metal engraver
 http://id.loc.gov/vocabulary/relators/mtk	mtk	minute taker	Minute taker	Protokoll
-http://id.loc.gov/vocabulary/relators/mup	mup	music programmer
+http://id.loc.gov/vocabulary/relators/mup	mup	music programmer	Music programmer
 http://id.loc.gov/vocabulary/relators/mus	mus	musician	Musician	Musiker/in
-http://id.loc.gov/vocabulary/relators/mxe	mxe	mixing engineer
-http://id.loc.gov/vocabulary/relators/nan	nan	news anchor
+http://id.loc.gov/vocabulary/relators/mxe	mxe	mixing engineer	Mixing engineer
+http://id.loc.gov/vocabulary/relators/nan	nan	news anchor	News anchor
 http://id.loc.gov/vocabulary/relators/nrt	nrt	narrator	Narrator	Erzähler/in
-http://id.loc.gov/vocabulary/relators/onp	onp	onscreen participant
-http://id.loc.gov/vocabulary/relators/opn	opn	opponent
+http://id.loc.gov/vocabulary/relators/onp	onp	onscreen participant	Onscreen participant
+http://id.loc.gov/vocabulary/relators/opn	opn	opponent	Opponent
 http://id.loc.gov/vocabulary/relators/org	org	originator	Originator	Begründet durch
 http://id.loc.gov/vocabulary/relators/orm	orm	organizer	Organizer	Veranstalter/in
 http://id.loc.gov/vocabulary/relators/osp	osp	onscreen presenter	On-screen presenter	On-Screen-Präsentator/in
 http://id.loc.gov/vocabulary/relators/oth	oth	other	Other agent associated with a work	Sonstige
 http://id.loc.gov/vocabulary/relators/own	own	owner	Owner	Eigentümer/in
-http://id.loc.gov/vocabulary/relators/pad	pad	place of address
+http://id.loc.gov/vocabulary/relators/pad	pad	place of address	Place of address
 http://id.loc.gov/vocabulary/relators/pan	pan	panelist	Panelist	Diskussionsteilnehmer/in
 http://id.loc.gov/vocabulary/relators/pat	pat	patron	Commissioning body	Im Auftrag von
 http://id.loc.gov/vocabulary/relators/pbd	pbd	publisher director	Editorial director	Chefredaktion
 http://id.loc.gov/vocabulary/relators/pbl	pbl	publisher	Publisher	Verlag
-http://id.loc.gov/vocabulary/relators/pdr	pdr	project director
-http://id.loc.gov/vocabulary/relators/pfr	pfr	proofreader
+http://id.loc.gov/vocabulary/relators/pdr	pdr	project director	Project director
+http://id.loc.gov/vocabulary/relators/pfr	pfr	proofreader	Proofreader
 http://id.loc.gov/vocabulary/relators/pht	pht	photographer	Photographer	Fotografie
 http://id.loc.gov/vocabulary/relators/plt	plt	platemaker	Platemaker	Druckformherstellung
-http://id.loc.gov/vocabulary/relators/pma	pma	permitting agency
-http://id.loc.gov/vocabulary/relators/pmn	pmn	production manager
-http://id.loc.gov/vocabulary/relators/pnc	pnc	penciller
-http://id.loc.gov/vocabulary/relators/pop	pop	printer of plates
+http://id.loc.gov/vocabulary/relators/pma	pma	permitting agency	Permitting agency
+http://id.loc.gov/vocabulary/relators/pmn	pmn	production manager	Production manager
+http://id.loc.gov/vocabulary/relators/pnc	pnc	penciller	Penciller
+http://id.loc.gov/vocabulary/relators/pop	pop	printer of plates	Printer of plates
 http://id.loc.gov/vocabulary/relators/ppm	ppm	papermaker	Papermaker	Papiermacher/in
 http://id.loc.gov/vocabulary/relators/ppt	ppt	puppeteer	Puppeteer	Puppenspieler/in
 http://id.loc.gov/vocabulary/relators/pra	pra	praeses	Praeses	Praeses
-http://id.loc.gov/vocabulary/relators/prc	prc	process contact
-http://id.loc.gov/vocabulary/relators/prd	prd	production personnel
+http://id.loc.gov/vocabulary/relators/prc	prc	process contact	Process contact
+http://id.loc.gov/vocabulary/relators/prd	prd	production personnel	Production personnel
 http://id.loc.gov/vocabulary/relators/pre	pre	presenter	Presenter	Präsentation
 http://id.loc.gov/vocabulary/relators/prf	prf	performer	Performer	Ausführende/r
 http://id.loc.gov/vocabulary/relators/prg	prg	programmer	Programmer	Programmiererung
 http://id.loc.gov/vocabulary/relators/prm	prm	printmaker	Printmaker	Druckgrafik
 http://id.loc.gov/vocabulary/relators/prn	prn	production company	Production company	Produktionsfirma
 http://id.loc.gov/vocabulary/relators/pro	pro	producer	Producer	Produktion
-http://id.loc.gov/vocabulary/relators/prp	prp	production place
+http://id.loc.gov/vocabulary/relators/prp	prp	production place	Production place
 http://id.loc.gov/vocabulary/relators/prs	prs	production designer	Production designer	Produktionsdesign
 http://id.loc.gov/vocabulary/relators/prt	prt	printer	Printer	Druck
-http://id.loc.gov/vocabulary/relators/prv	prv	provider
-http://id.loc.gov/vocabulary/relators/pta	pta	patent applicant
-http://id.loc.gov/vocabulary/relators/pte	pte	plaintiff-appellee
+http://id.loc.gov/vocabulary/relators/prv	prv	provider	Provider
+http://id.loc.gov/vocabulary/relators/pta	pta	patent applicant	Patent applicant
+http://id.loc.gov/vocabulary/relators/pte	pte	plaintiff-appellee	Plaintiff-appellee
 http://id.loc.gov/vocabulary/relators/ptf	ptf	plaintiff	Plaintiff	Zivilkläger/in
-http://id.loc.gov/vocabulary/relators/pth	pth	patent holder
-http://id.loc.gov/vocabulary/relators/ptt	ptt	plaintiff-appellant
-http://id.loc.gov/vocabulary/relators/pup	pup	publication place
-http://id.loc.gov/vocabulary/relators/rap	rap	rapporteur
-http://id.loc.gov/vocabulary/relators/rbr	rbr	rubricator
+http://id.loc.gov/vocabulary/relators/pth	pth	patent holder	Patent holder
+http://id.loc.gov/vocabulary/relators/ptt	ptt	plaintiff-appellant	Plaintiff-appellant
+http://id.loc.gov/vocabulary/relators/pup	pup	publication place	Publication place
+http://id.loc.gov/vocabulary/relators/rap	rap	rapporteur	Rapporteur
+http://id.loc.gov/vocabulary/relators/rbr	rbr	rubricator	Rubricator
 http://id.loc.gov/vocabulary/relators/rcd	rcd	recordist	Recordist	Ton
 http://id.loc.gov/vocabulary/relators/rce	rce	recording engineer	Recording engineer	Aufnahmetechniker/in
 http://id.loc.gov/vocabulary/relators/rcp	rcp	addressee	Addressee	Adressat/in
 http://id.loc.gov/vocabulary/relators/rdd	rdd	radio director	Radio director	Hörfunkregisseur/in
 http://id.loc.gov/vocabulary/relators/red	red	redaktor	Redaktor	Redaktion
-http://id.loc.gov/vocabulary/relators/ren	ren	renderer
+http://id.loc.gov/vocabulary/relators/ren	ren	renderer	Renderer
 http://id.loc.gov/vocabulary/relators/res	res	researcher	Researcher	Forscher/in
-http://id.loc.gov/vocabulary/relators/rev	rev	reviewer
+http://id.loc.gov/vocabulary/relators/rev	rev	reviewer	Reviewer
 http://id.loc.gov/vocabulary/relators/rpc	rpc	radio producer	Radio producer	Hörfunkproduktion
-http://id.loc.gov/vocabulary/relators/rps	rps	repository
-http://id.loc.gov/vocabulary/relators/rpt	rpt	reporter
-http://id.loc.gov/vocabulary/relators/rpy	rpy	responsible party
-http://id.loc.gov/vocabulary/relators/rse	rse	respondent-appellee
-http://id.loc.gov/vocabulary/relators/rsg	rsg	restager
+http://id.loc.gov/vocabulary/relators/rps	rps	repository	Repository
+http://id.loc.gov/vocabulary/relators/rpt	rpt	reporter	Reporter
+http://id.loc.gov/vocabulary/relators/rpy	rpy	responsible party	Responsible party
+http://id.loc.gov/vocabulary/relators/rse	rse	respondent-appellee	Respondent-appellee
+http://id.loc.gov/vocabulary/relators/rsg	rsg	restager	Restager
 http://id.loc.gov/vocabulary/relators/rsp	rsp	respondent	Respondent	Respondent/in
 http://id.loc.gov/vocabulary/relators/rsr	rsr	restorationist	Restorationist	Restaurator/in
-http://id.loc.gov/vocabulary/relators/rst	rst	respondent-appellant
-http://id.loc.gov/vocabulary/relators/rth	rth	research team head
-http://id.loc.gov/vocabulary/relators/rtm	rtm	research team member
-http://id.loc.gov/vocabulary/relators/rxa	rxa	remix artist
-http://id.loc.gov/vocabulary/relators/sad	sad	scientific advisor
-http://id.loc.gov/vocabulary/relators/sce	sce	scenarist
+http://id.loc.gov/vocabulary/relators/rst	rst	respondent-appellant	Respondent-appellant
+http://id.loc.gov/vocabulary/relators/rth	rth	research team head	Research team head
+http://id.loc.gov/vocabulary/relators/rtm	rtm	research team member	Research team member
+http://id.loc.gov/vocabulary/relators/rxa	rxa	remix artist	Remix artist
+http://id.loc.gov/vocabulary/relators/sad	sad	scientific advisor	Scientific advisor
+http://id.loc.gov/vocabulary/relators/sce	sce	scenarist	Scenarist
 http://id.loc.gov/vocabulary/relators/scl	scl	sculptor	Sculptor	Bildhauer/in
-http://id.loc.gov/vocabulary/relators/scr	scr	scribe
-http://id.loc.gov/vocabulary/relators/sde	sde	sound engineer
+http://id.loc.gov/vocabulary/relators/scr	scr	scribe	Scribe
+http://id.loc.gov/vocabulary/relators/sde	sde	sound engineer	Sound engineer
 http://id.loc.gov/vocabulary/relators/sds	sds	sound designer	Sound designer	Tongestaltung
-http://id.loc.gov/vocabulary/relators/sec	sec	secretary
-http://id.loc.gov/vocabulary/relators/sfx	sfx	special effects provider
+http://id.loc.gov/vocabulary/relators/sec	sec	secretary	Secretary
+http://id.loc.gov/vocabulary/relators/sfx	sfx	special effects provider	Special effects provider
 http://id.loc.gov/vocabulary/relators/sgd	sgd	stage director	Stage director	Bühnenregie
-http://id.loc.gov/vocabulary/relators/sgn	sgn	signer
-http://id.loc.gov/vocabulary/relators/sht	sht	supporting host
+http://id.loc.gov/vocabulary/relators/sgn	sgn	signer	Signer
+http://id.loc.gov/vocabulary/relators/sht	sht	supporting host	Supporting host
 http://id.loc.gov/vocabulary/relators/sll	sll	seller	Seller	Verkäufer/in
 http://id.loc.gov/vocabulary/relators/sng	sng	singer	Singer	Gesang
 http://id.loc.gov/vocabulary/relators/spk	spk	speaker	Speaker	Redner/in
 http://id.loc.gov/vocabulary/relators/spn	spn	sponsor	Sponsoring body	Träger/in
-http://id.loc.gov/vocabulary/relators/spy	spy	second party
+http://id.loc.gov/vocabulary/relators/spy	spy	second party	Second party
 http://id.loc.gov/vocabulary/relators/srv	srv	surveyor	Surveyor	Landvermessung
-http://id.loc.gov/vocabulary/relators/std	std	set designer
-http://id.loc.gov/vocabulary/relators/stg	stg	setting
+http://id.loc.gov/vocabulary/relators/std	std	set designer	Set designer
+http://id.loc.gov/vocabulary/relators/stg	stg	setting	Setting
 http://id.loc.gov/vocabulary/relators/stl	stl	storyteller	Storyteller	Geschichtenerzähler/in
-http://id.loc.gov/vocabulary/relators/stm	stm	stage manager
-http://id.loc.gov/vocabulary/relators/stn	stn	standards body
-http://id.loc.gov/vocabulary/relators/str	str	stereotyper
-http://id.loc.gov/vocabulary/relators/swd	swd	software developer
-http://id.loc.gov/vocabulary/relators/tad	tad	technical advisor
-http://id.loc.gov/vocabulary/relators/tau	tau	television writer
-http://id.loc.gov/vocabulary/relators/tcd	tcd	technical director
+http://id.loc.gov/vocabulary/relators/stm	stm	stage manager	Stage manager
+http://id.loc.gov/vocabulary/relators/stn	stn	standards body	Standards body
+http://id.loc.gov/vocabulary/relators/str	str	stereotyper	Stereotyper
+http://id.loc.gov/vocabulary/relators/swd	swd	software developer	Software developer
+http://id.loc.gov/vocabulary/relators/tad	tad	technical advisor	Technical advisor
+http://id.loc.gov/vocabulary/relators/tau	tau	television writer	Television writer
+http://id.loc.gov/vocabulary/relators/tcd	tcd	technical director	Technical director
 http://id.loc.gov/vocabulary/relators/tch	tch	teacher	Teacher	Ausbilder/in
-http://id.loc.gov/vocabulary/relators/ths	ths	thesis advisor
+http://id.loc.gov/vocabulary/relators/ths	ths	thesis advisor	Thesis advisor
 http://id.loc.gov/vocabulary/relators/tld	tld	television director	Television director	Fernsehregie
-http://id.loc.gov/vocabulary/relators/tlg	tlg	television guest
-http://id.loc.gov/vocabulary/relators/tlh	tlh	television host
+http://id.loc.gov/vocabulary/relators/tlg	tlg	television guest	Television guest
+http://id.loc.gov/vocabulary/relators/tlh	tlh	television host	Television host
 http://id.loc.gov/vocabulary/relators/tlp	tlp	television producer	Television producer	Fernsehproduktion
 http://id.loc.gov/vocabulary/relators/trc	trc	transcriber	Transcriber	Transkription
 http://id.loc.gov/vocabulary/relators/trl	trl	translator	Translator	Übersetzung
-http://id.loc.gov/vocabulary/relators/tyd	tyd	type designer
-http://id.loc.gov/vocabulary/relators/tyg	tyg	typographer
-http://id.loc.gov/vocabulary/relators/uvp	uvp	university place
+http://id.loc.gov/vocabulary/relators/tyd	tyd	type designer	Type designer
+http://id.loc.gov/vocabulary/relators/tyg	tyg	typographer	Typographer
+http://id.loc.gov/vocabulary/relators/uvp	uvp	university place	University place
 http://id.loc.gov/vocabulary/relators/vac	vac	voice actor	Voice actor	Synchronsprecher/in
 http://id.loc.gov/vocabulary/relators/vdg	vdg	videographer	Director of photography	Kamera
-http://id.loc.gov/vocabulary/relators/vfx	vfx	visual effects provider
-http://id.loc.gov/vocabulary/relators/voc	voc	vocalist
+http://id.loc.gov/vocabulary/relators/vfx	vfx	visual effects provider	Visual effects provider
+http://id.loc.gov/vocabulary/relators/voc	voc	vocalist	Vocalist
 http://id.loc.gov/vocabulary/relators/wac	wac	writer of added commentary	Writer of added commentary	Zusätzlicher Kommentar
 http://id.loc.gov/vocabulary/relators/wal	wal	writer of added lyrics	Writer of added lyrics	Verfasser/in von zusätzlichen Lyrics
-http://id.loc.gov/vocabulary/relators/wam	wam	writer of accompanying material
+http://id.loc.gov/vocabulary/relators/wam	wam	writer of accompanying material	Writer of accompanying material
 http://id.loc.gov/vocabulary/relators/wat	wat	writer of added text	Writer of added text	Zusätzlicher Text
-http://id.loc.gov/vocabulary/relators/waw	waw	writer of afterword
-http://id.loc.gov/vocabulary/relators/wdc	wdc	woodcutter
-http://id.loc.gov/vocabulary/relators/wde	wde	wood engraver
-http://id.loc.gov/vocabulary/relators/wfs	wfs	writer of film story
-http://id.loc.gov/vocabulary/relators/wft	wft	writer of intertitles
-http://id.loc.gov/vocabulary/relators/wfw	wfw	writer of foreword
+http://id.loc.gov/vocabulary/relators/waw	waw	writer of afterword	Writer of afterword
+http://id.loc.gov/vocabulary/relators/wdc	wdc	woodcutter	Woodcutter
+http://id.loc.gov/vocabulary/relators/wde	wde	wood engraver	Wood engraver
+http://id.loc.gov/vocabulary/relators/wfs	wfs	writer of film story	Writer of film story
+http://id.loc.gov/vocabulary/relators/wft	wft	writer of intertitles	Writer of intertitles
+http://id.loc.gov/vocabulary/relators/wfw	wfw	writer of foreword	Writer of foreword
 http://id.loc.gov/vocabulary/relators/win	win	writer of introduction	Writer of introduction	Einleitung
-http://id.loc.gov/vocabulary/relators/wit	wit	witness
+http://id.loc.gov/vocabulary/relators/wit	wit	witness	Witness
 http://id.loc.gov/vocabulary/relators/wpr	wpr	writer of preface	Writer of preface	Vorwort
 http://id.loc.gov/vocabulary/relators/wst	wst	writer of supplementary textual content	Writer of supplementary textual content	Verfasser/in von ergänzendem Text
-http://id.loc.gov/vocabulary/relators/wts	wts	writer of television story
+http://id.loc.gov/vocabulary/relators/wts	wts	writer of television story	Writer of television story


### PR DESCRIPTION
See [LoC Linked Data Service](https://id.loc.gov/vocabulary/relators.html).

Based on the [LoC TAB-delimited Data](http://id.loc.gov/vocabulary/relators.tsv), with English labels and German translations from [Lobid](https://github.com/hbz/lobid-resources/blob/master/src/main/resources/alma/maps/marcRel.tsv).

However, more than half of the entries are still untranslated. Does anybody have an idea how to fill in the missing German translations? I wasn't able to find any more complete/up-to-date source than the [DNB RDA documents](https://wiki.dnb.de/spaces/STAC/pages/289347346/RDA+Dokumente), which are already covered by Lobid.